### PR TITLE
Feat/unicode grapheme support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,6 +220,7 @@ dependencies = [
  "criterion",
  "glob",
  "globset",
+ "test-case",
 ]
 
 [[package]]
@@ -401,6 +402,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,6 +546,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-case"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a1d6e7bde536b0412f20765b76e921028059adfd1b90d8974d33fd3c91b25df"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-core"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d10394d5d1e27794f772b6fc854c7e91a2dc26e2cbf807ad523370c2a59c0cee"
+dependencies = [
+ "cfg-if",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeb9a44b1c6a54c1ba58b152797739dba2a83ca74e18168a68c980eb142f9404"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "test-case-core",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,6 +601,12 @@ name = "unicode-ident"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,7 @@ dependencies = [
  "glob",
  "globset",
  "test-case",
+ "unic-segment",
 ]
 
 [[package]]
@@ -594,6 +595,56 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "unic-char-property"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221"
+dependencies = [
+ "unic-char-range",
+]
+
+[[package]]
+name = "unic-char-range"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc"
+
+[[package]]
+name = "unic-common"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc"
+
+[[package]]
+name = "unic-segment"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ed5d26be57f84f176157270c112ef57b86debac9cd21daaabbe56db0f88f23"
+dependencies = [
+ "unic-ucd-segment",
+]
+
+[[package]]
+name = "unic-ucd-segment"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2079c122a62205b421f499da10f3ee0f7697f012f55b675e002483c73ea34700"
+dependencies = [
+ "unic-char-property",
+ "unic-char-range",
+ "unic-ucd-version",
+]
+
+[[package]]
+name = "unic-ucd-version"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
+dependencies = [
+ "unic-common",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 criterion = "0.4.0"
 glob = "0.3.1"
 globset = "0.4.10"
+test-case = "3.1.0"
 
 [[bench]]
 name = "bench"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,6 @@ harness = false
 lto = true
 codegen-units = 1
 panic = 'abort'
+
+[dependencies]
+unic-segment = {version = "0.9.0", optional = true}

--- a/README.md
+++ b/README.md
@@ -68,3 +68,25 @@ Data {
     input: "some input",
 }
 ```
+
+## Grapheme Support
+
+This library by default only considers single bytes at a time which can cause
+issues with matching against multi-byte unicode characters. Support for this
+can be enabled with the `unic-segment` feature, which uses a grapheme cursor
+to ensure that entire graphemes are respected.
+
+> **What is a grapheme?**
+> 
+> In short, a single 'symbol' on your screen. Not all
+> unicode characters are the same. Some take up a single byte, some up to
+> 4 bytes (UTF-8), and some even more than that depending on the type of
+> data. A UTF-8 codepoint is equivalent to a rust `char` which is a fixed 
+> 4 bytes in length. ASCII is a single byte, emoji can be up to 4 bytes (😱), 
+> but it is possible to have 'symbols' that are composed of multiple UTF-8 
+> codepoints such as flags 🇳🇴 or families 👨‍👩‍👦‍👦 which have 2 and 4 codepoints.
+> A collection of codepoints that make up a 'symbol' is your grapheme.
+
+This comes roughly at a 17% performance penalty, and is still significantly
+faster than glob and globset. Ranges are handled using a byte-by-byte 
+comparison. See the tests for examples on how this works.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -521,111 +521,114 @@ impl BraceStack {
 #[cfg(test)]
 mod tests {
   use super::*;
+  use test_case::test_case;
 
-  #[test]
-  fn basic() {
-    assert!(glob_match("abc", "abc"));
-    assert!(glob_match("*", "abc"));
-    assert!(glob_match("*", ""));
-    assert!(glob_match("**", ""));
-    assert!(glob_match("*c", "abc"));
-    assert!(!glob_match("*b", "abc"));
-    assert!(glob_match("a*", "abc"));
-    assert!(!glob_match("b*", "abc"));
-    assert!(glob_match("a*", "a"));
-    assert!(glob_match("*a", "a"));
-    assert!(glob_match("a*b*c*d*e*", "axbxcxdxe"));
-    assert!(glob_match("a*b*c*d*e*", "axbxcxdxexxx"));
-    assert!(glob_match("a*b?c*x", "abxbbxdbxebxczzx"));
-    assert!(!glob_match("a*b?c*x", "abxbbxdbxebxczzy"));
+  #[test_case("abc", "abc")]
+  #[test_case("*", "abc")]
+  #[test_case("*", "" ; "star with empty string")]
+  #[test_case("**", "" ; "globstar with empty string")]
+  #[test_case("*c", "abc")]
+  #[test_case("a*", "abc")]
+  #[test_case("a*", "a" ; "single char with star")]
+  #[test_case("*a", "a" ; "star with single char")]
+  #[test_case("a*b*c*d*e*", "axbxcxdxe")]
+  #[test_case("a*b*c*d*e*", "axbxcxdxexxx")]
+  #[test_case("a*b?c*x", "abxbbxdbxebxczzx")]
+  #[test_case("a/*/test", "a/foo/test" ; "path with star")]
+  #[test_case("a/**/test", "a/foo/test" ; "path with globstar")]
+  #[test_case("a/**/test", "a/foo/bar/test")]
+  #[test_case("a/**/b/c", "a/foo/bar/b/c")]
+  #[test_case("a\\*b", "a*b")]
+  #[test_case("[abc]", "a")]
+  #[test_case("[abc]", "b")]
+  #[test_case("[abc]", "c")]
+  #[test_case("x[abc]x", "xax")]
+  #[test_case("x[abc]x", "xbx")]
+  #[test_case("x[abc]x", "xcx")]
+  #[test_case("[?]", "?" ; "question match")]
+  #[test_case("[*]", "*" ; "star match")]
+  #[test_case("[a-cx]", "a")]
+  #[test_case("[a-cx]", "b")]
+  #[test_case("[a-cx]", "c")]
+  #[test_case("[a-cx]", "x")]
+  #[test_case("[^abc]", "d" ; "negated bracket")]
+  #[test_case("[!abc]", "d" ; "negated bracket 2")]
+  #[test_case("[\\!]", "!")]
+  #[test_case("a*b*[cy]*d*e*", "axbxcxdxexxx")]
+  #[test_case("a*b*[cy]*d*e*", "axbxyxdxexxx")]
+  #[test_case("a*b*[cy]*d*e*", "axbxxxyxdxexxx")]
+  #[test_case("test.{jpg,png}", "test.jpg")]
+  #[test_case("test.{jpg,png}", "test.png")]
+  #[test_case("test.{j*g,p*g}", "test.jpg")]
+  #[test_case("test.{j*g,p*g}", "test.jpxxxg")]
+  #[test_case("test.{j*g,p*g}", "test.jxg")]
+  #[test_case("test.{j*g,j*c}", "test.jnc")]
+  #[test_case("test.{jpg,p*g}", "test.png")]
+  #[test_case("test.{jpg,p*g}", "test.pxg")]
+  #[test_case("test.{jpeg,png}", "test.jpeg")]
+  #[test_case("test.{jpeg,png}", "test.png")]
+  #[test_case("test.{jp\\,g,png}", "test.jp,g")]
+  #[test_case("test/{foo,bar}/baz", "test/foo/baz")]
+  #[test_case("test/{foo,bar}/baz", "test/bar/baz" ; "braces with slash")]
+  #[test_case("test/{foo*,bar*}/baz", "test/foooooo/baz")]
+  #[test_case("test/{foo*,bar*}/baz", "test/barrrrr/baz")]
+  #[test_case("test/{*foo,*bar}/baz", "test/xxxxfoo/baz")]
+  #[test_case("test/{*foo,*bar}/baz", "test/xxxxbar/baz")]
+  #[test_case("test/{foo/**,bar}/baz", "test/bar/baz" ; "globstar in braces")]
+  #[test_case("a/{a{a,b},b}", "a/aa")]
+  #[test_case("a/{a{a,b},b}", "a/ab")]
+  #[test_case("a/{a{a,b},b}", "a/b")]
+  #[test_case("a/{b,c[}]*}", "a/b")]
+  #[test_case("a/{b,c[}]*}", "a/c}xx")]
+  #[test_case(
+    "some/**/needle.{js,tsx,mdx,ts,jsx,txt}",
+    "some/a/bigger/path/to/the/crazy/needle.txt"
+  )]
+  #[test_case(
+    "some/**/{a,b,c}/**/needle.txt",
+    "some/foo/a/bigger/path/to/the/crazy/needle.txt"
+  )]
+  fn basic(path: &str, glob: &str) {
+    assert!(
+      glob_match(path, glob),
+      "`{}` doesn't match `{}`",
+      path,
+      glob
+    );
+  }
 
-    assert!(glob_match("a/*/test", "a/foo/test"));
-    assert!(!glob_match("a/*/test", "a/foo/bar/test"));
-    assert!(glob_match("a/**/test", "a/foo/test"));
-    assert!(glob_match("a/**/test", "a/foo/bar/test"));
-    assert!(glob_match("a/**/b/c", "a/foo/bar/b/c"));
-    assert!(glob_match("a\\*b", "a*b"));
-    assert!(!glob_match("a\\*b", "axb"));
-
-    assert!(glob_match("[abc]", "a"));
-    assert!(glob_match("[abc]", "b"));
-    assert!(glob_match("[abc]", "c"));
-    assert!(!glob_match("[abc]", "d"));
-    assert!(glob_match("x[abc]x", "xax"));
-    assert!(glob_match("x[abc]x", "xbx"));
-    assert!(glob_match("x[abc]x", "xcx"));
-    assert!(!glob_match("x[abc]x", "xdx"));
-    assert!(!glob_match("x[abc]x", "xay"));
-    assert!(glob_match("[?]", "?"));
-    assert!(!glob_match("[?]", "a"));
-    assert!(glob_match("[*]", "*"));
-    assert!(!glob_match("[*]", "a"));
-
-    assert!(glob_match("[a-cx]", "a"));
-    assert!(glob_match("[a-cx]", "b"));
-    assert!(glob_match("[a-cx]", "c"));
-    assert!(!glob_match("[a-cx]", "d"));
-    assert!(glob_match("[a-cx]", "x"));
-
-    assert!(!glob_match("[^abc]", "a"));
-    assert!(!glob_match("[^abc]", "b"));
-    assert!(!glob_match("[^abc]", "c"));
-    assert!(glob_match("[^abc]", "d"));
-    assert!(!glob_match("[!abc]", "a"));
-    assert!(!glob_match("[!abc]", "b"));
-    assert!(!glob_match("[!abc]", "c"));
-    assert!(glob_match("[!abc]", "d"));
-    assert!(glob_match("[\\!]", "!"));
-
-    assert!(glob_match("a*b*[cy]*d*e*", "axbxcxdxexxx"));
-    assert!(glob_match("a*b*[cy]*d*e*", "axbxyxdxexxx"));
-    assert!(glob_match("a*b*[cy]*d*e*", "axbxxxyxdxexxx"));
-
-    assert!(glob_match("test.{jpg,png}", "test.jpg"));
-    assert!(glob_match("test.{jpg,png}", "test.png"));
-    assert!(glob_match("test.{j*g,p*g}", "test.jpg"));
-    assert!(glob_match("test.{j*g,p*g}", "test.jpxxxg"));
-    assert!(glob_match("test.{j*g,p*g}", "test.jxg"));
-    assert!(!glob_match("test.{j*g,p*g}", "test.jnt"));
-    assert!(glob_match("test.{j*g,j*c}", "test.jnc"));
-    assert!(glob_match("test.{jpg,p*g}", "test.png"));
-    assert!(glob_match("test.{jpg,p*g}", "test.pxg"));
-    assert!(!glob_match("test.{jpg,p*g}", "test.pnt"));
-    assert!(glob_match("test.{jpeg,png}", "test.jpeg"));
-    assert!(!glob_match("test.{jpeg,png}", "test.jpg"));
-    assert!(glob_match("test.{jpeg,png}", "test.png"));
-    assert!(glob_match("test.{jp\\,g,png}", "test.jp,g"));
-    assert!(!glob_match("test.{jp\\,g,png}", "test.jxg"));
-    assert!(glob_match("test/{foo,bar}/baz", "test/foo/baz"));
-    assert!(glob_match("test/{foo,bar}/baz", "test/bar/baz"));
-    assert!(!glob_match("test/{foo,bar}/baz", "test/baz/baz"));
-    assert!(glob_match("test/{foo*,bar*}/baz", "test/foooooo/baz"));
-    assert!(glob_match("test/{foo*,bar*}/baz", "test/barrrrr/baz"));
-    assert!(glob_match("test/{*foo,*bar}/baz", "test/xxxxfoo/baz"));
-    assert!(glob_match("test/{*foo,*bar}/baz", "test/xxxxbar/baz"));
-    assert!(glob_match("test/{foo/**,bar}/baz", "test/bar/baz"));
-    assert!(!glob_match("test/{foo/**,bar}/baz", "test/bar/test/baz"));
-
-    assert!(!glob_match("*.txt", "some/big/path/to/the/needle.txt"));
-    assert!(glob_match(
-      "some/**/needle.{js,tsx,mdx,ts,jsx,txt}",
-      "some/a/bigger/path/to/the/crazy/needle.txt"
-    ));
-    assert!(glob_match(
-      "some/**/{a,b,c}/**/needle.txt",
-      "some/foo/a/bigger/path/to/the/crazy/needle.txt"
-    ));
-    assert!(!glob_match(
-      "some/**/{a,b,c}/**/needle.txt",
-      "some/foo/d/bigger/path/to/the/crazy/needle.txt"
-    ));
-    assert!(glob_match("a/{a{a,b},b}", "a/aa"));
-    assert!(glob_match("a/{a{a,b},b}", "a/ab"));
-    assert!(!glob_match("a/{a{a,b},b}", "a/ac"));
-    assert!(glob_match("a/{a{a,b},b}", "a/b"));
-    assert!(!glob_match("a/{a{a,b},b}", "a/c"));
-    assert!(glob_match("a/{b,c[}]*}", "a/b"));
-    assert!(glob_match("a/{b,c[}]*}", "a/c}xx"));
+  #[test_case("*b", "abc" ; "star with char mismatch")]
+  #[test_case("b*", "abc" ; "char with star mismatch")]
+  #[test_case("a*b?c*x", "abxbbxdbxebxczzy")]
+  #[test_case("a/*/test", "a/foo/bar/test")]
+  #[test_case("a\\*b", "axb")]
+  #[test_case("[abc]", "d")]
+  #[test_case("x[abc]x", "xdx")]
+  #[test_case("x[abc]x", "xay")]
+  #[test_case("[?]", "a" ; "question mismatch")]
+  #[test_case("[*]", "a" ; "star mismatch")]
+  #[test_case("[a-cx]", "d")]
+  #[test_case("[^abc]", "a" ; "negated bracket mismatch")]
+  #[test_case("[^abc]", "b" ; "negated bracket mismatch 2")]
+  #[test_case("[^abc]", "c" ; "negated bracket mismatch 3")]
+  #[test_case("[!abc]", "a" ; "negated bracket mismatch 4")]
+  #[test_case("[!abc]", "b" ; "negated bracket mismatch 5")]
+  #[test_case("[!abc]", "c" ; "negated bracket mismatch 6")]
+  #[test_case("test.{j*g,p*g}", "test.jnt")]
+  #[test_case("test.{jpg,p*g}", "test.pnt")]
+  #[test_case("test.{jpeg,png}", "test.jpg")]
+  #[test_case("test.{jp\\,g,png}", "test.jxg")]
+  #[test_case("test/{foo,bar}/baz", "test/baz/baz")]
+  #[test_case("test/{foo/**,bar}/baz", "test/bar/test/baz")]
+  #[test_case("*.txt", "some/big/path/to/the/needle.txt")]
+  #[test_case("a/{a{a,b},b}", "a/ac")]
+  #[test_case("a/{a{a,b},b}", "a/c")]
+  #[test_case(
+    "some/**/{a,b,c}/**/needle.txt",
+    "some/foo/d/bigger/path/to/the/crazy/needle.txt"
+  )]
+  fn basic_not(glob: &str, path: &str) {
+    assert!(!glob_match(glob, path), "`{}` matches `{}`", path, glob);
   }
 
   // The below tests are based on Bash and micromatch.
@@ -634,1516 +637,1352 @@ mod tests {
   // find: assert\(([!])?isMatch\('(.*?)', ['"](.*?)['"]\)\);
   // replace: assert!($1glob_match("$3", "$2"));
 
-  #[test]
-  fn bash() {
-    assert!(!glob_match("a*", "*"));
-    assert!(!glob_match("a*", "**"));
-    assert!(!glob_match("a*", "\\*"));
-    assert!(!glob_match("a*", "a/*"));
-    assert!(!glob_match("a*", "b"));
-    assert!(!glob_match("a*", "bc"));
-    assert!(!glob_match("a*", "bcd"));
-    assert!(!glob_match("a*", "bdir/"));
-    assert!(!glob_match("a*", "Beware"));
-    assert!(glob_match("a*", "a"));
-    assert!(glob_match("a*", "ab"));
-    assert!(glob_match("a*", "abc"));
-
-    assert!(!glob_match("\\a*", "*"));
-    assert!(!glob_match("\\a*", "**"));
-    assert!(!glob_match("\\a*", "\\*"));
-
-    assert!(glob_match("\\a*", "a"));
-    assert!(!glob_match("\\a*", "a/*"));
-    assert!(glob_match("\\a*", "abc"));
-    assert!(glob_match("\\a*", "abd"));
-    assert!(glob_match("\\a*", "abe"));
-    assert!(!glob_match("\\a*", "b"));
-    assert!(!glob_match("\\a*", "bb"));
-    assert!(!glob_match("\\a*", "bcd"));
-    assert!(!glob_match("\\a*", "bdir/"));
-    assert!(!glob_match("\\a*", "Beware"));
-    assert!(!glob_match("\\a*", "c"));
-    assert!(!glob_match("\\a*", "ca"));
-    assert!(!glob_match("\\a*", "cb"));
-    assert!(!glob_match("\\a*", "d"));
-    assert!(!glob_match("\\a*", "dd"));
-    assert!(!glob_match("\\a*", "de"));
-  }
-
-  #[test]
-  fn bash_directories() {
-    assert!(!glob_match("b*/", "*"));
-    assert!(!glob_match("b*/", "**"));
-    assert!(!glob_match("b*/", "\\*"));
-    assert!(!glob_match("b*/", "a"));
-    assert!(!glob_match("b*/", "a/*"));
-    assert!(!glob_match("b*/", "abc"));
-    assert!(!glob_match("b*/", "abd"));
-    assert!(!glob_match("b*/", "abe"));
-    assert!(!glob_match("b*/", "b"));
-    assert!(!glob_match("b*/", "bb"));
-    assert!(!glob_match("b*/", "bcd"));
-    assert!(glob_match("b*/", "bdir/"));
-    assert!(!glob_match("b*/", "Beware"));
-    assert!(!glob_match("b*/", "c"));
-    assert!(!glob_match("b*/", "ca"));
-    assert!(!glob_match("b*/", "cb"));
-    assert!(!glob_match("b*/", "d"));
-    assert!(!glob_match("b*/", "dd"));
-    assert!(!glob_match("b*/", "de"));
-  }
-
-  #[test]
-  fn bash_escaping() {
-    assert!(!glob_match("\\^", "*"));
-    assert!(!glob_match("\\^", "**"));
-    assert!(!glob_match("\\^", "\\*"));
-    assert!(!glob_match("\\^", "a"));
-    assert!(!glob_match("\\^", "a/*"));
-    assert!(!glob_match("\\^", "abc"));
-    assert!(!glob_match("\\^", "abd"));
-    assert!(!glob_match("\\^", "abe"));
-    assert!(!glob_match("\\^", "b"));
-    assert!(!glob_match("\\^", "bb"));
-    assert!(!glob_match("\\^", "bcd"));
-    assert!(!glob_match("\\^", "bdir/"));
-    assert!(!glob_match("\\^", "Beware"));
-    assert!(!glob_match("\\^", "c"));
-    assert!(!glob_match("\\^", "ca"));
-    assert!(!glob_match("\\^", "cb"));
-    assert!(!glob_match("\\^", "d"));
-    assert!(!glob_match("\\^", "dd"));
-    assert!(!glob_match("\\^", "de"));
-
-    assert!(glob_match("\\*", "*"));
-    // assert!(glob_match("\\*", "\\*"));
-    assert!(!glob_match("\\*", "**"));
-    assert!(!glob_match("\\*", "a"));
-    assert!(!glob_match("\\*", "a/*"));
-    assert!(!glob_match("\\*", "abc"));
-    assert!(!glob_match("\\*", "abd"));
-    assert!(!glob_match("\\*", "abe"));
-    assert!(!glob_match("\\*", "b"));
-    assert!(!glob_match("\\*", "bb"));
-    assert!(!glob_match("\\*", "bcd"));
-    assert!(!glob_match("\\*", "bdir/"));
-    assert!(!glob_match("\\*", "Beware"));
-    assert!(!glob_match("\\*", "c"));
-    assert!(!glob_match("\\*", "ca"));
-    assert!(!glob_match("\\*", "cb"));
-    assert!(!glob_match("\\*", "d"));
-    assert!(!glob_match("\\*", "dd"));
-    assert!(!glob_match("\\*", "de"));
-
-    assert!(!glob_match("a\\*", "*"));
-    assert!(!glob_match("a\\*", "**"));
-    assert!(!glob_match("a\\*", "\\*"));
-    assert!(!glob_match("a\\*", "a"));
-    assert!(!glob_match("a\\*", "a/*"));
-    assert!(!glob_match("a\\*", "abc"));
-    assert!(!glob_match("a\\*", "abd"));
-    assert!(!glob_match("a\\*", "abe"));
-    assert!(!glob_match("a\\*", "b"));
-    assert!(!glob_match("a\\*", "bb"));
-    assert!(!glob_match("a\\*", "bcd"));
-    assert!(!glob_match("a\\*", "bdir/"));
-    assert!(!glob_match("a\\*", "Beware"));
-    assert!(!glob_match("a\\*", "c"));
-    assert!(!glob_match("a\\*", "ca"));
-    assert!(!glob_match("a\\*", "cb"));
-    assert!(!glob_match("a\\*", "d"));
-    assert!(!glob_match("a\\*", "dd"));
-    assert!(!glob_match("a\\*", "de"));
-
-    assert!(glob_match("*q*", "aqa"));
-    assert!(glob_match("*q*", "aaqaa"));
-    assert!(!glob_match("*q*", "*"));
-    assert!(!glob_match("*q*", "**"));
-    assert!(!glob_match("*q*", "\\*"));
-    assert!(!glob_match("*q*", "a"));
-    assert!(!glob_match("*q*", "a/*"));
-    assert!(!glob_match("*q*", "abc"));
-    assert!(!glob_match("*q*", "abd"));
-    assert!(!glob_match("*q*", "abe"));
-    assert!(!glob_match("*q*", "b"));
-    assert!(!glob_match("*q*", "bb"));
-    assert!(!glob_match("*q*", "bcd"));
-    assert!(!glob_match("*q*", "bdir/"));
-    assert!(!glob_match("*q*", "Beware"));
-    assert!(!glob_match("*q*", "c"));
-    assert!(!glob_match("*q*", "ca"));
-    assert!(!glob_match("*q*", "cb"));
-    assert!(!glob_match("*q*", "d"));
-    assert!(!glob_match("*q*", "dd"));
-    assert!(!glob_match("*q*", "de"));
-
-    assert!(glob_match("\\**", "*"));
-    assert!(glob_match("\\**", "**"));
-    assert!(!glob_match("\\**", "\\*"));
-    assert!(!glob_match("\\**", "a"));
-    assert!(!glob_match("\\**", "a/*"));
-    assert!(!glob_match("\\**", "abc"));
-    assert!(!glob_match("\\**", "abd"));
-    assert!(!glob_match("\\**", "abe"));
-    assert!(!glob_match("\\**", "b"));
-    assert!(!glob_match("\\**", "bb"));
-    assert!(!glob_match("\\**", "bcd"));
-    assert!(!glob_match("\\**", "bdir/"));
-    assert!(!glob_match("\\**", "Beware"));
-    assert!(!glob_match("\\**", "c"));
-    assert!(!glob_match("\\**", "ca"));
-    assert!(!glob_match("\\**", "cb"));
-    assert!(!glob_match("\\**", "d"));
-    assert!(!glob_match("\\**", "dd"));
-    assert!(!glob_match("\\**", "de"));
-  }
-
-  #[test]
-  fn bash_classes() {
-    assert!(!glob_match("a*[^c]", "*"));
-    assert!(!glob_match("a*[^c]", "**"));
-    assert!(!glob_match("a*[^c]", "\\*"));
-    assert!(!glob_match("a*[^c]", "a"));
-    assert!(!glob_match("a*[^c]", "a/*"));
-    assert!(!glob_match("a*[^c]", "abc"));
-    assert!(glob_match("a*[^c]", "abd"));
-    assert!(glob_match("a*[^c]", "abe"));
-    assert!(!glob_match("a*[^c]", "b"));
-    assert!(!glob_match("a*[^c]", "bb"));
-    assert!(!glob_match("a*[^c]", "bcd"));
-    assert!(!glob_match("a*[^c]", "bdir/"));
-    assert!(!glob_match("a*[^c]", "Beware"));
-    assert!(!glob_match("a*[^c]", "c"));
-    assert!(!glob_match("a*[^c]", "ca"));
-    assert!(!glob_match("a*[^c]", "cb"));
-    assert!(!glob_match("a*[^c]", "d"));
-    assert!(!glob_match("a*[^c]", "dd"));
-    assert!(!glob_match("a*[^c]", "de"));
-    assert!(!glob_match("a*[^c]", "baz"));
-    assert!(!glob_match("a*[^c]", "bzz"));
-    assert!(!glob_match("a*[^c]", "BZZ"));
-    assert!(!glob_match("a*[^c]", "beware"));
-    assert!(!glob_match("a*[^c]", "BewAre"));
-
-    assert!(glob_match("a[X-]b", "a-b"));
-    assert!(glob_match("a[X-]b", "aXb"));
-
-    assert!(!glob_match("[a-y]*[^c]", "*"));
-    assert!(glob_match("[a-y]*[^c]", "a*"));
-    assert!(!glob_match("[a-y]*[^c]", "**"));
-    assert!(!glob_match("[a-y]*[^c]", "\\*"));
-    assert!(!glob_match("[a-y]*[^c]", "a"));
-    assert!(glob_match("[a-y]*[^c]", "a123b"));
-    assert!(!glob_match("[a-y]*[^c]", "a123c"));
-    assert!(glob_match("[a-y]*[^c]", "ab"));
-    assert!(!glob_match("[a-y]*[^c]", "a/*"));
-    assert!(!glob_match("[a-y]*[^c]", "abc"));
-    assert!(glob_match("[a-y]*[^c]", "abd"));
-    assert!(glob_match("[a-y]*[^c]", "abe"));
-    assert!(!glob_match("[a-y]*[^c]", "b"));
-    assert!(glob_match("[a-y]*[^c]", "bd"));
-    assert!(glob_match("[a-y]*[^c]", "bb"));
-    assert!(glob_match("[a-y]*[^c]", "bcd"));
-    assert!(glob_match("[a-y]*[^c]", "bdir/"));
-    assert!(!glob_match("[a-y]*[^c]", "Beware"));
-    assert!(!glob_match("[a-y]*[^c]", "c"));
-    assert!(glob_match("[a-y]*[^c]", "ca"));
-    assert!(glob_match("[a-y]*[^c]", "cb"));
-    assert!(!glob_match("[a-y]*[^c]", "d"));
-    assert!(glob_match("[a-y]*[^c]", "dd"));
-    assert!(glob_match("[a-y]*[^c]", "dd"));
-    assert!(glob_match("[a-y]*[^c]", "dd"));
-    assert!(glob_match("[a-y]*[^c]", "de"));
-    assert!(glob_match("[a-y]*[^c]", "baz"));
-    assert!(glob_match("[a-y]*[^c]", "bzz"));
-    assert!(glob_match("[a-y]*[^c]", "bzz"));
-    // assert(!isMatch('bzz', '[a-y]*[^c]', { regex: true }));
-    assert!(!glob_match("[a-y]*[^c]", "BZZ"));
-    assert!(glob_match("[a-y]*[^c]", "beware"));
-    assert!(!glob_match("[a-y]*[^c]", "BewAre"));
-
-    assert!(glob_match("a\\*b/*", "a*b/ooo"));
-    assert!(glob_match("a\\*?/*", "a*b/ooo"));
-
-    assert!(!glob_match("a[b]c", "*"));
-    assert!(!glob_match("a[b]c", "**"));
-    assert!(!glob_match("a[b]c", "\\*"));
-    assert!(!glob_match("a[b]c", "a"));
-    assert!(!glob_match("a[b]c", "a/*"));
-    assert!(glob_match("a[b]c", "abc"));
-    assert!(!glob_match("a[b]c", "abd"));
-    assert!(!glob_match("a[b]c", "abe"));
-    assert!(!glob_match("a[b]c", "b"));
-    assert!(!glob_match("a[b]c", "bb"));
-    assert!(!glob_match("a[b]c", "bcd"));
-    assert!(!glob_match("a[b]c", "bdir/"));
-    assert!(!glob_match("a[b]c", "Beware"));
-    assert!(!glob_match("a[b]c", "c"));
-    assert!(!glob_match("a[b]c", "ca"));
-    assert!(!glob_match("a[b]c", "cb"));
-    assert!(!glob_match("a[b]c", "d"));
-    assert!(!glob_match("a[b]c", "dd"));
-    assert!(!glob_match("a[b]c", "de"));
-    assert!(!glob_match("a[b]c", "baz"));
-    assert!(!glob_match("a[b]c", "bzz"));
-    assert!(!glob_match("a[b]c", "BZZ"));
-    assert!(!glob_match("a[b]c", "beware"));
-    assert!(!glob_match("a[b]c", "BewAre"));
-
-    assert!(!glob_match("a[\"b\"]c", "*"));
-    assert!(!glob_match("a[\"b\"]c", "**"));
-    assert!(!glob_match("a[\"b\"]c", "\\*"));
-    assert!(!glob_match("a[\"b\"]c", "a"));
-    assert!(!glob_match("a[\"b\"]c", "a/*"));
-    assert!(glob_match("a[\"b\"]c", "abc"));
-    assert!(!glob_match("a[\"b\"]c", "abd"));
-    assert!(!glob_match("a[\"b\"]c", "abe"));
-    assert!(!glob_match("a[\"b\"]c", "b"));
-    assert!(!glob_match("a[\"b\"]c", "bb"));
-    assert!(!glob_match("a[\"b\"]c", "bcd"));
-    assert!(!glob_match("a[\"b\"]c", "bdir/"));
-    assert!(!glob_match("a[\"b\"]c", "Beware"));
-    assert!(!glob_match("a[\"b\"]c", "c"));
-    assert!(!glob_match("a[\"b\"]c", "ca"));
-    assert!(!glob_match("a[\"b\"]c", "cb"));
-    assert!(!glob_match("a[\"b\"]c", "d"));
-    assert!(!glob_match("a[\"b\"]c", "dd"));
-    assert!(!glob_match("a[\"b\"]c", "de"));
-    assert!(!glob_match("a[\"b\"]c", "baz"));
-    assert!(!glob_match("a[\"b\"]c", "bzz"));
-    assert!(!glob_match("a[\"b\"]c", "BZZ"));
-    assert!(!glob_match("a[\"b\"]c", "beware"));
-    assert!(!glob_match("a[\"b\"]c", "BewAre"));
-
-    assert!(!glob_match("a[\\\\b]c", "*"));
-    assert!(!glob_match("a[\\\\b]c", "**"));
-    assert!(!glob_match("a[\\\\b]c", "\\*"));
-    assert!(!glob_match("a[\\\\b]c", "a"));
-    assert!(!glob_match("a[\\\\b]c", "a/*"));
-    assert!(glob_match("a[\\\\b]c", "abc"));
-    assert!(!glob_match("a[\\\\b]c", "abd"));
-    assert!(!glob_match("a[\\\\b]c", "abe"));
-    assert!(!glob_match("a[\\\\b]c", "b"));
-    assert!(!glob_match("a[\\\\b]c", "bb"));
-    assert!(!glob_match("a[\\\\b]c", "bcd"));
-    assert!(!glob_match("a[\\\\b]c", "bdir/"));
-    assert!(!glob_match("a[\\\\b]c", "Beware"));
-    assert!(!glob_match("a[\\\\b]c", "c"));
-    assert!(!glob_match("a[\\\\b]c", "ca"));
-    assert!(!glob_match("a[\\\\b]c", "cb"));
-    assert!(!glob_match("a[\\\\b]c", "d"));
-    assert!(!glob_match("a[\\\\b]c", "dd"));
-    assert!(!glob_match("a[\\\\b]c", "de"));
-    assert!(!glob_match("a[\\\\b]c", "baz"));
-    assert!(!glob_match("a[\\\\b]c", "bzz"));
-    assert!(!glob_match("a[\\\\b]c", "BZZ"));
-    assert!(!glob_match("a[\\\\b]c", "beware"));
-    assert!(!glob_match("a[\\\\b]c", "BewAre"));
-
-    assert!(!glob_match("a[\\b]c", "*"));
-    assert!(!glob_match("a[\\b]c", "**"));
-    assert!(!glob_match("a[\\b]c", "\\*"));
-    assert!(!glob_match("a[\\b]c", "a"));
-    assert!(!glob_match("a[\\b]c", "a/*"));
-    assert!(!glob_match("a[\\b]c", "abc"));
-    assert!(!glob_match("a[\\b]c", "abd"));
-    assert!(!glob_match("a[\\b]c", "abe"));
-    assert!(!glob_match("a[\\b]c", "b"));
-    assert!(!glob_match("a[\\b]c", "bb"));
-    assert!(!glob_match("a[\\b]c", "bcd"));
-    assert!(!glob_match("a[\\b]c", "bdir/"));
-    assert!(!glob_match("a[\\b]c", "Beware"));
-    assert!(!glob_match("a[\\b]c", "c"));
-    assert!(!glob_match("a[\\b]c", "ca"));
-    assert!(!glob_match("a[\\b]c", "cb"));
-    assert!(!glob_match("a[\\b]c", "d"));
-    assert!(!glob_match("a[\\b]c", "dd"));
-    assert!(!glob_match("a[\\b]c", "de"));
-    assert!(!glob_match("a[\\b]c", "baz"));
-    assert!(!glob_match("a[\\b]c", "bzz"));
-    assert!(!glob_match("a[\\b]c", "BZZ"));
-    assert!(!glob_match("a[\\b]c", "beware"));
-    assert!(!glob_match("a[\\b]c", "BewAre"));
-
-    assert!(!glob_match("a[b-d]c", "*"));
-    assert!(!glob_match("a[b-d]c", "**"));
-    assert!(!glob_match("a[b-d]c", "\\*"));
-    assert!(!glob_match("a[b-d]c", "a"));
-    assert!(!glob_match("a[b-d]c", "a/*"));
-    assert!(glob_match("a[b-d]c", "abc"));
-    assert!(!glob_match("a[b-d]c", "abd"));
-    assert!(!glob_match("a[b-d]c", "abe"));
-    assert!(!glob_match("a[b-d]c", "b"));
-    assert!(!glob_match("a[b-d]c", "bb"));
-    assert!(!glob_match("a[b-d]c", "bcd"));
-    assert!(!glob_match("a[b-d]c", "bdir/"));
-    assert!(!glob_match("a[b-d]c", "Beware"));
-    assert!(!glob_match("a[b-d]c", "c"));
-    assert!(!glob_match("a[b-d]c", "ca"));
-    assert!(!glob_match("a[b-d]c", "cb"));
-    assert!(!glob_match("a[b-d]c", "d"));
-    assert!(!glob_match("a[b-d]c", "dd"));
-    assert!(!glob_match("a[b-d]c", "de"));
-    assert!(!glob_match("a[b-d]c", "baz"));
-    assert!(!glob_match("a[b-d]c", "bzz"));
-    assert!(!glob_match("a[b-d]c", "BZZ"));
-    assert!(!glob_match("a[b-d]c", "beware"));
-    assert!(!glob_match("a[b-d]c", "BewAre"));
-
-    assert!(!glob_match("a?c", "*"));
-    assert!(!glob_match("a?c", "**"));
-    assert!(!glob_match("a?c", "\\*"));
-    assert!(!glob_match("a?c", "a"));
-    assert!(!glob_match("a?c", "a/*"));
-    assert!(glob_match("a?c", "abc"));
-    assert!(!glob_match("a?c", "abd"));
-    assert!(!glob_match("a?c", "abe"));
-    assert!(!glob_match("a?c", "b"));
-    assert!(!glob_match("a?c", "bb"));
-    assert!(!glob_match("a?c", "bcd"));
-    assert!(!glob_match("a?c", "bdir/"));
-    assert!(!glob_match("a?c", "Beware"));
-    assert!(!glob_match("a?c", "c"));
-    assert!(!glob_match("a?c", "ca"));
-    assert!(!glob_match("a?c", "cb"));
-    assert!(!glob_match("a?c", "d"));
-    assert!(!glob_match("a?c", "dd"));
-    assert!(!glob_match("a?c", "de"));
-    assert!(!glob_match("a?c", "baz"));
-    assert!(!glob_match("a?c", "bzz"));
-    assert!(!glob_match("a?c", "BZZ"));
-    assert!(!glob_match("a?c", "beware"));
-    assert!(!glob_match("a?c", "BewAre"));
-
-    assert!(glob_match("*/man*/bash.*", "man/man1/bash.1"));
-
-    assert!(glob_match("[^a-c]*", "*"));
-    assert!(glob_match("[^a-c]*", "**"));
-    assert!(!glob_match("[^a-c]*", "a"));
-    assert!(!glob_match("[^a-c]*", "a/*"));
-    assert!(!glob_match("[^a-c]*", "abc"));
-    assert!(!glob_match("[^a-c]*", "abd"));
-    assert!(!glob_match("[^a-c]*", "abe"));
-    assert!(!glob_match("[^a-c]*", "b"));
-    assert!(!glob_match("[^a-c]*", "bb"));
-    assert!(!glob_match("[^a-c]*", "bcd"));
-    assert!(!glob_match("[^a-c]*", "bdir/"));
-    assert!(glob_match("[^a-c]*", "Beware"));
-    assert!(glob_match("[^a-c]*", "Beware"));
-    assert!(!glob_match("[^a-c]*", "c"));
-    assert!(!glob_match("[^a-c]*", "ca"));
-    assert!(!glob_match("[^a-c]*", "cb"));
-    assert!(glob_match("[^a-c]*", "d"));
-    assert!(glob_match("[^a-c]*", "dd"));
-    assert!(glob_match("[^a-c]*", "de"));
-    assert!(!glob_match("[^a-c]*", "baz"));
-    assert!(!glob_match("[^a-c]*", "bzz"));
-    assert!(glob_match("[^a-c]*", "BZZ"));
-    assert!(!glob_match("[^a-c]*", "beware"));
-    assert!(glob_match("[^a-c]*", "BewAre"));
-  }
-
-  #[test]
-  fn bash_wildmatch() {
-    assert!(!glob_match("a[]-]b", "aab"));
-    assert!(!glob_match("[ten]", "ten"));
-    assert!(glob_match("]", "]"));
-    assert!(glob_match("a[]-]b", "a-b"));
-    assert!(glob_match("a[]-]b", "a]b"));
-    assert!(glob_match("a[]]b", "a]b"));
-    assert!(glob_match("a[\\]a\\-]b", "aab"));
-    assert!(glob_match("t[a-g]n", "ten"));
-    assert!(glob_match("t[^a-g]n", "ton"));
-  }
-
-  #[test]
-  fn bash_slashmatch() {
-    // assert!(!glob_match("f[^eiu][^eiu][^eiu][^eiu][^eiu]r", "foo/bar"));
-    assert!(glob_match("foo[/]bar", "foo/bar"));
-    assert!(glob_match("f[^eiu][^eiu][^eiu][^eiu][^eiu]r", "foo-bar"));
-  }
-
-  #[test]
-  fn bash_extra_stars() {
-    assert!(!glob_match("a**c", "bbc"));
-    assert!(glob_match("a**c", "abc"));
-    assert!(!glob_match("a**c", "bbd"));
-
-    assert!(!glob_match("a***c", "bbc"));
-    assert!(glob_match("a***c", "abc"));
-    assert!(!glob_match("a***c", "bbd"));
-
-    assert!(!glob_match("a*****?c", "bbc"));
-    assert!(glob_match("a*****?c", "abc"));
-    assert!(!glob_match("a*****?c", "bbc"));
-
-    assert!(glob_match("?*****??", "bbc"));
-    assert!(glob_match("?*****??", "abc"));
-
-    assert!(glob_match("*****??", "bbc"));
-    assert!(glob_match("*****??", "abc"));
-
-    assert!(glob_match("?*****?c", "bbc"));
-    assert!(glob_match("?*****?c", "abc"));
-
-    assert!(glob_match("?***?****c", "bbc"));
-    assert!(glob_match("?***?****c", "abc"));
-    assert!(!glob_match("?***?****c", "bbd"));
-
-    assert!(glob_match("?***?****?", "bbc"));
-    assert!(glob_match("?***?****?", "abc"));
-
-    assert!(glob_match("?***?****", "bbc"));
-    assert!(glob_match("?***?****", "abc"));
-
-    assert!(glob_match("*******c", "bbc"));
-    assert!(glob_match("*******c", "abc"));
-
-    assert!(glob_match("*******?", "bbc"));
-    assert!(glob_match("*******?", "abc"));
-
-    assert!(glob_match("a*cd**?**??k", "abcdecdhjk"));
-    assert!(glob_match("a**?**cd**?**??k", "abcdecdhjk"));
-    assert!(glob_match("a**?**cd**?**??k***", "abcdecdhjk"));
-    assert!(glob_match("a**?**cd**?**??***k", "abcdecdhjk"));
-    assert!(glob_match("a**?**cd**?**??***k**", "abcdecdhjk"));
-    assert!(glob_match("a****c**?**??*****", "abcdecdhjk"));
-  }
-
-  #[test]
-  fn stars() {
-    assert!(!glob_match("*.js", "a/b/c/z.js"));
-    assert!(!glob_match("*.js", "a/b/z.js"));
-    assert!(!glob_match("*.js", "a/z.js"));
-    assert!(glob_match("*.js", "z.js"));
-
-    // assert!(!glob_match("*/*", "a/.ab"));
-    // assert!(!glob_match("*", ".ab"));
-
-    assert!(glob_match("z*.js", "z.js"));
-    assert!(glob_match("*/*", "a/z"));
-    assert!(glob_match("*/z*.js", "a/z.js"));
-    assert!(glob_match("a/z*.js", "a/z.js"));
-
-    assert!(glob_match("*", "ab"));
-    assert!(glob_match("*", "abc"));
-
-    assert!(!glob_match("f*", "bar"));
-    assert!(!glob_match("*r", "foo"));
-    assert!(!glob_match("b*", "foo"));
-    assert!(!glob_match("*", "foo/bar"));
-    assert!(glob_match("*c", "abc"));
-    assert!(glob_match("a*", "abc"));
-    assert!(glob_match("a*c", "abc"));
-    assert!(glob_match("*r", "bar"));
-    assert!(glob_match("b*", "bar"));
-    assert!(glob_match("f*", "foo"));
-
-    assert!(glob_match("*abc*", "one abc two"));
-    assert!(glob_match("a*b", "a         b"));
-
-    assert!(!glob_match("*a*", "foo"));
-    assert!(glob_match("*a*", "bar"));
-    assert!(glob_match("*abc*", "oneabctwo"));
-    assert!(!glob_match("*-bc-*", "a-b.c-d"));
-    assert!(glob_match("*-*.*-*", "a-b.c-d"));
-    assert!(glob_match("*-b*c-*", "a-b.c-d"));
-    assert!(glob_match("*-b.c-*", "a-b.c-d"));
-    assert!(glob_match("*.*", "a-b.c-d"));
-    assert!(glob_match("*.*-*", "a-b.c-d"));
-    assert!(glob_match("*.*-d", "a-b.c-d"));
-    assert!(glob_match("*.c-*", "a-b.c-d"));
-    assert!(glob_match("*b.*d", "a-b.c-d"));
-    assert!(glob_match("a*.c*", "a-b.c-d"));
-    assert!(glob_match("a-*.*-d", "a-b.c-d"));
-    assert!(glob_match("*.*", "a.b"));
-    assert!(glob_match("*.b", "a.b"));
-    assert!(glob_match("a.*", "a.b"));
-    assert!(glob_match("a.b", "a.b"));
-
-    assert!(!glob_match("**-bc-**", "a-b.c-d"));
-    assert!(glob_match("**-**.**-**", "a-b.c-d"));
-    assert!(glob_match("**-b**c-**", "a-b.c-d"));
-    assert!(glob_match("**-b.c-**", "a-b.c-d"));
-    assert!(glob_match("**.**", "a-b.c-d"));
-    assert!(glob_match("**.**-**", "a-b.c-d"));
-    assert!(glob_match("**.**-d", "a-b.c-d"));
-    assert!(glob_match("**.c-**", "a-b.c-d"));
-    assert!(glob_match("**b.**d", "a-b.c-d"));
-    assert!(glob_match("a**.c**", "a-b.c-d"));
-    assert!(glob_match("a-**.**-d", "a-b.c-d"));
-    assert!(glob_match("**.**", "a.b"));
-    assert!(glob_match("**.b", "a.b"));
-    assert!(glob_match("a.**", "a.b"));
-    assert!(glob_match("a.b", "a.b"));
-
-    assert!(glob_match("*/*", "/ab"));
-    assert!(glob_match(".", "."));
-    assert!(!glob_match("a/", "a/.b"));
-    assert!(glob_match("/*", "/ab"));
-    assert!(glob_match("/??", "/ab"));
-    assert!(glob_match("/?b", "/ab"));
-    assert!(glob_match("/*", "/cd"));
-    assert!(glob_match("a", "a"));
-    assert!(glob_match("a/.*", "a/.b"));
-    assert!(glob_match("?/?", "a/b"));
-    assert!(glob_match("a/**/j/**/z/*.md", "a/b/c/d/e/j/n/p/o/z/c.md"));
-    assert!(glob_match("a/**/z/*.md", "a/b/c/d/e/z/c.md"));
-    assert!(glob_match("a/b/c/*.md", "a/b/c/xyz.md"));
-    assert!(glob_match("a/b/c/*.md", "a/b/c/xyz.md"));
-    assert!(glob_match("a/*/z/.a", "a/b/z/.a"));
-    assert!(!glob_match("bz", "a/b/z/.a"));
-    assert!(glob_match("a/**/c/*.md", "a/bb.bb/aa/b.b/aa/c/xyz.md"));
-    assert!(glob_match("a/**/c/*.md", "a/bb.bb/aa/bb/aa/c/xyz.md"));
-    assert!(glob_match("a/*/c/*.md", "a/bb.bb/c/xyz.md"));
-    assert!(glob_match("a/*/c/*.md", "a/bb/c/xyz.md"));
-    assert!(glob_match("a/*/c/*.md", "a/bbbb/c/xyz.md"));
-    assert!(glob_match("*", "aaa"));
-    assert!(glob_match("*", "ab"));
-    assert!(glob_match("ab", "ab"));
-
-    assert!(!glob_match("*/*/*", "aaa"));
-    assert!(!glob_match("*/*/*", "aaa/bb/aa/rr"));
-    assert!(!glob_match("aaa*", "aaa/bba/ccc"));
-    // assert!(!glob_match("aaa**", "aaa/bba/ccc"));
-    assert!(!glob_match("aaa/*", "aaa/bba/ccc"));
-    assert!(!glob_match("aaa/*ccc", "aaa/bba/ccc"));
-    assert!(!glob_match("aaa/*z", "aaa/bba/ccc"));
-    assert!(!glob_match("*/*/*", "aaa/bbb"));
-    assert!(!glob_match("*/*jk*/*i", "ab/zzz/ejkl/hi"));
-    assert!(glob_match("*/*/*", "aaa/bba/ccc"));
-    assert!(glob_match("aaa/**", "aaa/bba/ccc"));
-    assert!(glob_match("aaa/*", "aaa/bbb"));
-    assert!(glob_match("*/*z*/*/*i", "ab/zzz/ejkl/hi"));
-    assert!(glob_match("*j*i", "abzzzejklhi"));
-
-    assert!(glob_match("*", "a"));
-    assert!(glob_match("*", "b"));
-    assert!(!glob_match("*", "a/a"));
-    assert!(!glob_match("*", "a/a/a"));
-    assert!(!glob_match("*", "a/a/b"));
-    assert!(!glob_match("*", "a/a/a/a"));
-    assert!(!glob_match("*", "a/a/a/a/a"));
-
-    assert!(!glob_match("*/*", "a"));
-    assert!(glob_match("*/*", "a/a"));
-    assert!(!glob_match("*/*", "a/a/a"));
-
-    assert!(!glob_match("*/*/*", "a"));
-    assert!(!glob_match("*/*/*", "a/a"));
-    assert!(glob_match("*/*/*", "a/a/a"));
-    assert!(!glob_match("*/*/*", "a/a/a/a"));
-
-    assert!(!glob_match("*/*/*/*", "a"));
-    assert!(!glob_match("*/*/*/*", "a/a"));
-    assert!(!glob_match("*/*/*/*", "a/a/a"));
-    assert!(glob_match("*/*/*/*", "a/a/a/a"));
-    assert!(!glob_match("*/*/*/*", "a/a/a/a/a"));
-
-    assert!(!glob_match("*/*/*/*/*", "a"));
-    assert!(!glob_match("*/*/*/*/*", "a/a"));
-    assert!(!glob_match("*/*/*/*/*", "a/a/a"));
-    assert!(!glob_match("*/*/*/*/*", "a/a/b"));
-    assert!(!glob_match("*/*/*/*/*", "a/a/a/a"));
-    assert!(glob_match("*/*/*/*/*", "a/a/a/a/a"));
-    assert!(!glob_match("*/*/*/*/*", "a/a/a/a/a/a"));
-
-    assert!(!glob_match("a/*", "a"));
-    assert!(glob_match("a/*", "a/a"));
-    assert!(!glob_match("a/*", "a/a/a"));
-    assert!(!glob_match("a/*", "a/a/a/a"));
-    assert!(!glob_match("a/*", "a/a/a/a/a"));
-
-    assert!(!glob_match("a/*/*", "a"));
-    assert!(!glob_match("a/*/*", "a/a"));
-    assert!(glob_match("a/*/*", "a/a/a"));
-    assert!(!glob_match("a/*/*", "b/a/a"));
-    assert!(!glob_match("a/*/*", "a/a/a/a"));
-    assert!(!glob_match("a/*/*", "a/a/a/a/a"));
-
-    assert!(!glob_match("a/*/*/*", "a"));
-    assert!(!glob_match("a/*/*/*", "a/a"));
-    assert!(!glob_match("a/*/*/*", "a/a/a"));
-    assert!(glob_match("a/*/*/*", "a/a/a/a"));
-    assert!(!glob_match("a/*/*/*", "a/a/a/a/a"));
-
-    assert!(!glob_match("a/*/*/*/*", "a"));
-    assert!(!glob_match("a/*/*/*/*", "a/a"));
-    assert!(!glob_match("a/*/*/*/*", "a/a/a"));
-    assert!(!glob_match("a/*/*/*/*", "a/a/b"));
-    assert!(!glob_match("a/*/*/*/*", "a/a/a/a"));
-    assert!(glob_match("a/*/*/*/*", "a/a/a/a/a"));
-
-    assert!(!glob_match("a/*/a", "a"));
-    assert!(!glob_match("a/*/a", "a/a"));
-    assert!(glob_match("a/*/a", "a/a/a"));
-    assert!(!glob_match("a/*/a", "a/a/b"));
-    assert!(!glob_match("a/*/a", "a/a/a/a"));
-    assert!(!glob_match("a/*/a", "a/a/a/a/a"));
-
-    assert!(!glob_match("a/*/b", "a"));
-    assert!(!glob_match("a/*/b", "a/a"));
-    assert!(!glob_match("a/*/b", "a/a/a"));
-    assert!(glob_match("a/*/b", "a/a/b"));
-    assert!(!glob_match("a/*/b", "a/a/a/a"));
-    assert!(!glob_match("a/*/b", "a/a/a/a/a"));
-
-    assert!(!glob_match("*/**/a", "a"));
-    assert!(!glob_match("*/**/a", "a/a/b"));
-    assert!(glob_match("*/**/a", "a/a"));
-    assert!(glob_match("*/**/a", "a/a/a"));
-    assert!(glob_match("*/**/a", "a/a/a/a"));
-    assert!(glob_match("*/**/a", "a/a/a/a/a"));
-
-    assert!(!glob_match("*/", "a"));
-    assert!(!glob_match("*/*", "a"));
-    assert!(!glob_match("a/*", "a"));
-    // assert!(!glob_match("*/*", "a/"));
-    // assert!(!glob_match("a/*", "a/"));
-    assert!(!glob_match("*", "a/a"));
-    assert!(!glob_match("*/", "a/a"));
-    assert!(!glob_match("*/", "a/x/y"));
-    assert!(!glob_match("*/*", "a/x/y"));
-    assert!(!glob_match("a/*", "a/x/y"));
-    // assert!(glob_match("*", "a/"));
-    assert!(glob_match("*", "a"));
-    assert!(glob_match("*/", "a/"));
-    assert!(glob_match("*{,/}", "a/"));
-    assert!(glob_match("*/*", "a/a"));
-    assert!(glob_match("a/*", "a/a"));
-
-    assert!(!glob_match("a/**/*.txt", "a.txt"));
-    assert!(glob_match("a/**/*.txt", "a/x/y.txt"));
-    assert!(!glob_match("a/**/*.txt", "a/x/y/z"));
-
-    assert!(!glob_match("a/*.txt", "a.txt"));
-    assert!(glob_match("a/*.txt", "a/b.txt"));
-    assert!(!glob_match("a/*.txt", "a/x/y.txt"));
-    assert!(!glob_match("a/*.txt", "a/x/y/z"));
-
-    assert!(glob_match("a*.txt", "a.txt"));
-    assert!(!glob_match("a*.txt", "a/b.txt"));
-    assert!(!glob_match("a*.txt", "a/x/y.txt"));
-    assert!(!glob_match("a*.txt", "a/x/y/z"));
-
-    assert!(glob_match("*.txt", "a.txt"));
-    assert!(!glob_match("*.txt", "a/b.txt"));
-    assert!(!glob_match("*.txt", "a/x/y.txt"));
-    assert!(!glob_match("*.txt", "a/x/y/z"));
-
-    assert!(!glob_match("a*", "a/b"));
-    assert!(!glob_match("a/**/b", "a/a/bb"));
-    assert!(!glob_match("a/**/b", "a/bb"));
-
-    assert!(!glob_match("*/**", "foo"));
-    assert!(!glob_match("**/", "foo/bar"));
-    assert!(!glob_match("**/*/", "foo/bar"));
-    assert!(!glob_match("*/*/", "foo/bar"));
-
-    assert!(glob_match("**/..", "/home/foo/.."));
-    assert!(glob_match("**/a", "a"));
-    assert!(glob_match("**", "a/a"));
-    assert!(glob_match("a/**", "a/a"));
-    assert!(glob_match("a/**", "a/"));
-    // assert!(glob_match("a/**", "a"));
-    assert!(!glob_match("**/", "a/a"));
-    // assert!(glob_match("**/a/**", "a"));
-    // assert!(glob_match("a/**", "a"));
-    assert!(!glob_match("**/", "a/a"));
-    assert!(glob_match("*/**/a", "a/a"));
-    // assert!(glob_match("a/**", "a"));
-    assert!(glob_match("*/**", "foo/"));
-    assert!(glob_match("**/*", "foo/bar"));
-    assert!(glob_match("*/*", "foo/bar"));
-    assert!(glob_match("*/**", "foo/bar"));
-    assert!(glob_match("**/", "foo/bar/"));
-    // assert!(glob_match("**/*", "foo/bar/"));
-    assert!(glob_match("**/*/", "foo/bar/"));
-    assert!(glob_match("*/**", "foo/bar/"));
-    assert!(glob_match("*/*/", "foo/bar/"));
-
-    assert!(!glob_match("*/foo", "bar/baz/foo"));
-    assert!(!glob_match("**/bar/*", "deep/foo/bar"));
-    assert!(!glob_match("*/bar/**", "deep/foo/bar/baz/x"));
-    assert!(!glob_match("/*", "ef"));
-    assert!(!glob_match("foo?bar", "foo/bar"));
-    assert!(!glob_match("**/bar*", "foo/bar/baz"));
-    // assert!(!glob_match("**/bar**", "foo/bar/baz"));
-    assert!(!glob_match("foo**bar", "foo/baz/bar"));
-    assert!(!glob_match("foo*bar", "foo/baz/bar"));
-    // assert!(glob_match("foo/**", "foo"));
-    assert!(glob_match("/*", "/ab"));
-    assert!(glob_match("/*", "/cd"));
-    assert!(glob_match("/*", "/ef"));
-    assert!(glob_match("a/**/j/**/z/*.md", "a/b/j/c/z/x.md"));
-    assert!(glob_match("a/**/j/**/z/*.md", "a/j/z/x.md"));
-
-    assert!(glob_match("**/foo", "bar/baz/foo"));
-    assert!(glob_match("**/bar/*", "deep/foo/bar/baz"));
-    assert!(glob_match("**/bar/**", "deep/foo/bar/baz/"));
-    assert!(glob_match("**/bar/*/*", "deep/foo/bar/baz/x"));
-    assert!(glob_match("foo/**/**/bar", "foo/b/a/z/bar"));
-    assert!(glob_match("foo/**/bar", "foo/b/a/z/bar"));
-    assert!(glob_match("foo/**/**/bar", "foo/bar"));
-    assert!(glob_match("foo/**/bar", "foo/bar"));
-    assert!(glob_match("*/bar/**", "foo/bar/baz/x"));
-    assert!(glob_match("foo/**/**/bar", "foo/baz/bar"));
-    assert!(glob_match("foo/**/bar", "foo/baz/bar"));
-    assert!(glob_match("**/foo", "XXX/foo"));
-  }
-
-  #[test]
-  fn globstars() {
-    assert!(glob_match("**/*.js", "a/b/c/d.js"));
-    assert!(glob_match("**/*.js", "a/b/c.js"));
-    assert!(glob_match("**/*.js", "a/b.js"));
-    assert!(glob_match("a/b/**/*.js", "a/b/c/d/e/f.js"));
-    assert!(glob_match("a/b/**/*.js", "a/b/c/d/e.js"));
-    assert!(glob_match("a/b/c/**/*.js", "a/b/c/d.js"));
-    assert!(glob_match("a/b/**/*.js", "a/b/c/d.js"));
-    assert!(glob_match("a/b/**/*.js", "a/b/d.js"));
-    assert!(!glob_match("a/b/**/*.js", "a/d.js"));
-    assert!(!glob_match("a/b/**/*.js", "d.js"));
-
-    assert!(!glob_match("**c", "a/b/c"));
-    assert!(!glob_match("a/**c", "a/b/c"));
-    assert!(!glob_match("a/**z", "a/b/c"));
-    assert!(!glob_match("a/**b**/c", "a/b/c/b/c"));
-    assert!(!glob_match("a/b/c**/*.js", "a/b/c/d/e.js"));
-    assert!(glob_match("a/**/b/**/c", "a/b/c/b/c"));
-    assert!(glob_match("a/**b**/c", "a/aba/c"));
-    assert!(glob_match("a/**b**/c", "a/b/c"));
-    assert!(glob_match("a/b/c**/*.js", "a/b/c/d.js"));
-
-    assert!(!glob_match("a/**/*", "a"));
-    assert!(!glob_match("a/**/**/*", "a"));
-    assert!(!glob_match("a/**/**/**/*", "a"));
-    assert!(!glob_match("**/a", "a/"));
-    assert!(!glob_match("a/**/*", "a/"));
-    assert!(!glob_match("a/**/**/*", "a/"));
-    assert!(!glob_match("a/**/**/**/*", "a/"));
-    assert!(!glob_match("**/a", "a/b"));
-    assert!(!glob_match("a/**/j/**/z/*.md", "a/b/c/j/e/z/c.txt"));
-    assert!(!glob_match("a/**/b", "a/bb"));
-    assert!(!glob_match("**/a", "a/c"));
-    assert!(!glob_match("**/a", "a/b"));
-    assert!(!glob_match("**/a", "a/x/y"));
-    assert!(!glob_match("**/a", "a/b/c/d"));
-    assert!(glob_match("**", "a"));
-    assert!(glob_match("**/a", "a"));
-    // assert!(glob_match("a/**", "a"));
-    assert!(glob_match("**", "a/"));
-    assert!(glob_match("**/a/**", "a/"));
-    assert!(glob_match("a/**", "a/"));
-    assert!(glob_match("a/**/**", "a/"));
-    assert!(glob_match("**/a", "a/a"));
-    assert!(glob_match("**", "a/b"));
-    assert!(glob_match("*/*", "a/b"));
-    assert!(glob_match("a/**", "a/b"));
-    assert!(glob_match("a/**/*", "a/b"));
-    assert!(glob_match("a/**/**/*", "a/b"));
-    assert!(glob_match("a/**/**/**/*", "a/b"));
-    assert!(glob_match("a/**/b", "a/b"));
-    assert!(glob_match("**", "a/b/c"));
-    assert!(glob_match("**/*", "a/b/c"));
-    assert!(glob_match("**/**", "a/b/c"));
-    assert!(glob_match("*/**", "a/b/c"));
-    assert!(glob_match("a/**", "a/b/c"));
-    assert!(glob_match("a/**/*", "a/b/c"));
-    assert!(glob_match("a/**/**/*", "a/b/c"));
-    assert!(glob_match("a/**/**/**/*", "a/b/c"));
-    assert!(glob_match("**", "a/b/c/d"));
-    assert!(glob_match("a/**", "a/b/c/d"));
-    assert!(glob_match("a/**/*", "a/b/c/d"));
-    assert!(glob_match("a/**/**/*", "a/b/c/d"));
-    assert!(glob_match("a/**/**/**/*", "a/b/c/d"));
-    assert!(glob_match("a/b/**/c/**/*.*", "a/b/c/d.e"));
-    assert!(glob_match("a/**/f/*.md", "a/b/c/d/e/f/g.md"));
-    assert!(glob_match("a/**/f/**/k/*.md", "a/b/c/d/e/f/g/h/i/j/k/l.md"));
-    assert!(glob_match("a/b/c/*.md", "a/b/c/def.md"));
-    assert!(glob_match("a/*/c/*.md", "a/bb.bb/c/ddd.md"));
-    assert!(glob_match("a/**/f/*.md", "a/bb.bb/cc/d.d/ee/f/ggg.md"));
-    assert!(glob_match("a/**/f/*.md", "a/bb.bb/cc/dd/ee/f/ggg.md"));
-    assert!(glob_match("a/*/c/*.md", "a/bb/c/ddd.md"));
-    assert!(glob_match("a/*/c/*.md", "a/bbbb/c/ddd.md"));
-
-    assert!(glob_match(
-      "foo/bar/**/one/**/*.*",
-      "foo/bar/baz/one/image.png"
-    ));
-    assert!(glob_match(
-      "foo/bar/**/one/**/*.*",
-      "foo/bar/baz/one/two/image.png"
-    ));
-    assert!(glob_match(
-      "foo/bar/**/one/**/*.*",
-      "foo/bar/baz/one/two/three/image.png"
-    ));
-    assert!(!glob_match("a/b/**/f", "a/b/c/d/"));
-    // assert!(glob_match("a/**", "a"));
-    assert!(glob_match("**", "a"));
-    // assert!(glob_match("a{,/**}", "a"));
-    assert!(glob_match("**", "a/"));
-    assert!(glob_match("a/**", "a/"));
-    assert!(glob_match("**", "a/b/c/d"));
-    assert!(glob_match("**", "a/b/c/d/"));
-    assert!(glob_match("**/**", "a/b/c/d/"));
-    assert!(glob_match("**/b/**", "a/b/c/d/"));
-    assert!(glob_match("a/b/**", "a/b/c/d/"));
-    assert!(glob_match("a/b/**/", "a/b/c/d/"));
-    assert!(glob_match("a/b/**/c/**/", "a/b/c/d/"));
-    assert!(glob_match("a/b/**/c/**/d/", "a/b/c/d/"));
-    assert!(glob_match("a/b/**/**/*.*", "a/b/c/d/e.f"));
-    assert!(glob_match("a/b/**/*.*", "a/b/c/d/e.f"));
-    assert!(glob_match("a/b/**/c/**/d/*.*", "a/b/c/d/e.f"));
-    assert!(glob_match("a/b/**/d/**/*.*", "a/b/c/d/e.f"));
-    assert!(glob_match("a/b/**/d/**/*.*", "a/b/c/d/g/e.f"));
-    assert!(glob_match("a/b/**/d/**/*.*", "a/b/c/d/g/g/e.f"));
-    assert!(glob_match("a/b-*/**/z.js", "a/b-c/z.js"));
-    assert!(glob_match("a/b-*/**/z.js", "a/b-c/d/e/z.js"));
-
-    assert!(glob_match("*/*", "a/b"));
-    assert!(glob_match("a/b/c/*.md", "a/b/c/xyz.md"));
-    assert!(glob_match("a/*/c/*.md", "a/bb.bb/c/xyz.md"));
-    assert!(glob_match("a/*/c/*.md", "a/bb/c/xyz.md"));
-    assert!(glob_match("a/*/c/*.md", "a/bbbb/c/xyz.md"));
-
-    assert!(glob_match("**/*", "a/b/c"));
-    assert!(glob_match("**/**", "a/b/c"));
-    assert!(glob_match("*/**", "a/b/c"));
-    assert!(glob_match("a/**/j/**/z/*.md", "a/b/c/d/e/j/n/p/o/z/c.md"));
-    assert!(glob_match("a/**/z/*.md", "a/b/c/d/e/z/c.md"));
-    assert!(glob_match("a/**/c/*.md", "a/bb.bb/aa/b.b/aa/c/xyz.md"));
-    assert!(glob_match("a/**/c/*.md", "a/bb.bb/aa/bb/aa/c/xyz.md"));
-    assert!(!glob_match("a/**/j/**/z/*.md", "a/b/c/j/e/z/c.txt"));
-    assert!(!glob_match("a/b/**/c{d,e}/**/xyz.md", "a/b/c/xyz.md"));
-    assert!(!glob_match("a/b/**/c{d,e}/**/xyz.md", "a/b/d/xyz.md"));
-    assert!(!glob_match("a/**/", "a/b"));
-    // assert!(!glob_match("**/*", "a/b/.js/c.txt"));
-    assert!(!glob_match("a/**/", "a/b/c/d"));
-    assert!(!glob_match("a/**/", "a/bb"));
-    assert!(!glob_match("a/**/", "a/cb"));
-    assert!(glob_match("/**", "/a/b"));
-    assert!(glob_match("**/*", "a.b"));
-    assert!(glob_match("**/*", "a.js"));
-    assert!(glob_match("**/*.js", "a.js"));
-    // assert!(glob_match("a/**/", "a/"));
-    assert!(glob_match("**/*.js", "a/a.js"));
-    assert!(glob_match("**/*.js", "a/a/b.js"));
-    assert!(glob_match("a/**/b", "a/b"));
-    assert!(glob_match("a/**b", "a/b"));
-    assert!(glob_match("**/*.md", "a/b.md"));
-    assert!(glob_match("**/*", "a/b/c.js"));
-    assert!(glob_match("**/*", "a/b/c.txt"));
-    assert!(glob_match("a/**/", "a/b/c/d/"));
-    assert!(glob_match("**/*", "a/b/c/d/a.js"));
-    assert!(glob_match("a/b/**/*.js", "a/b/c/z.js"));
-    assert!(glob_match("a/b/**/*.js", "a/b/z.js"));
-    assert!(glob_match("**/*", "ab"));
-    assert!(glob_match("**/*", "ab/c"));
-    assert!(glob_match("**/*", "ab/c/d"));
-    assert!(glob_match("**/*", "abc.js"));
-
-    assert!(!glob_match("**/", "a"));
-    assert!(!glob_match("**/a/*", "a"));
-    assert!(!glob_match("**/a/*/*", "a"));
-    assert!(!glob_match("*/a/**", "a"));
-    assert!(!glob_match("a/**/*", "a"));
-    assert!(!glob_match("a/**/**/*", "a"));
-    assert!(!glob_match("**/", "a/b"));
-    assert!(!glob_match("**/b/*", "a/b"));
-    assert!(!glob_match("**/b/*/*", "a/b"));
-    assert!(!glob_match("b/**", "a/b"));
-    assert!(!glob_match("**/", "a/b/c"));
-    assert!(!glob_match("**/**/b", "a/b/c"));
-    assert!(!glob_match("**/b", "a/b/c"));
-    assert!(!glob_match("**/b/*/*", "a/b/c"));
-    assert!(!glob_match("b/**", "a/b/c"));
-    assert!(!glob_match("**/", "a/b/c/d"));
-    assert!(!glob_match("**/d/*", "a/b/c/d"));
-    assert!(!glob_match("b/**", "a/b/c/d"));
-    assert!(glob_match("**", "a"));
-    assert!(glob_match("**/**", "a"));
-    assert!(glob_match("**/**/*", "a"));
-    assert!(glob_match("**/**/a", "a"));
-    assert!(glob_match("**/a", "a"));
-    // assert!(glob_match("**/a/**", "a"));
-    // assert!(glob_match("a/**", "a"));
-    assert!(glob_match("**", "a/b"));
-    assert!(glob_match("**/**", "a/b"));
-    assert!(glob_match("**/**/*", "a/b"));
-    assert!(glob_match("**/**/b", "a/b"));
-    assert!(glob_match("**/b", "a/b"));
-    // assert!(glob_match("**/b/**", "a/b"));
-    // assert!(glob_match("*/b/**", "a/b"));
-    assert!(glob_match("a/**", "a/b"));
-    assert!(glob_match("a/**/*", "a/b"));
-    assert!(glob_match("a/**/**/*", "a/b"));
-    assert!(glob_match("**", "a/b/c"));
-    assert!(glob_match("**/**", "a/b/c"));
-    assert!(glob_match("**/**/*", "a/b/c"));
-    assert!(glob_match("**/b/*", "a/b/c"));
-    assert!(glob_match("**/b/**", "a/b/c"));
-    assert!(glob_match("*/b/**", "a/b/c"));
-    assert!(glob_match("a/**", "a/b/c"));
-    assert!(glob_match("a/**/*", "a/b/c"));
-    assert!(glob_match("a/**/**/*", "a/b/c"));
-    assert!(glob_match("**", "a/b/c/d"));
-    assert!(glob_match("**/**", "a/b/c/d"));
-    assert!(glob_match("**/**/*", "a/b/c/d"));
-    assert!(glob_match("**/**/d", "a/b/c/d"));
-    assert!(glob_match("**/b/**", "a/b/c/d"));
-    assert!(glob_match("**/b/*/*", "a/b/c/d"));
-    assert!(glob_match("**/d", "a/b/c/d"));
-    assert!(glob_match("*/b/**", "a/b/c/d"));
-    assert!(glob_match("a/**", "a/b/c/d"));
-    assert!(glob_match("a/**/*", "a/b/c/d"));
-    assert!(glob_match("a/**/**/*", "a/b/c/d"));
-  }
-
-  #[test]
-  fn utf8() {
-    assert!(glob_match("フ*/**/*", "フォルダ/aaa.js"));
-    assert!(glob_match("フォ*/**/*", "フォルダ/aaa.js"));
-    assert!(glob_match("フォル*/**/*", "フォルダ/aaa.js"));
-    assert!(glob_match("フ*ル*/**/*", "フォルダ/aaa.js"));
-    assert!(glob_match("フォルダ/**/*", "フォルダ/aaa.js"));
-  }
-
-  #[test]
-  fn negation() {
-    assert!(!glob_match("!*", "abc"));
-    assert!(!glob_match("!abc", "abc"));
-    assert!(!glob_match("*!.md", "bar.md"));
-    assert!(!glob_match("foo!.md", "bar.md"));
-    assert!(!glob_match("\\!*!*.md", "foo!.md"));
-    assert!(!glob_match("\\!*!*.md", "foo!bar.md"));
-    assert!(glob_match("*!*.md", "!foo!.md"));
-    assert!(glob_match("\\!*!*.md", "!foo!.md"));
-    assert!(glob_match("!*foo", "abc"));
-    assert!(glob_match("!foo*", "abc"));
-    assert!(glob_match("!xyz", "abc"));
-    assert!(glob_match("*!*.*", "ba!r.js"));
-    assert!(glob_match("*.md", "bar.md"));
-    assert!(glob_match("*!*.*", "foo!.md"));
-    assert!(glob_match("*!*.md", "foo!.md"));
-    assert!(glob_match("*!.md", "foo!.md"));
-    assert!(glob_match("*.md", "foo!.md"));
-    assert!(glob_match("foo!.md", "foo!.md"));
-    assert!(glob_match("*!*.md", "foo!bar.md"));
-    assert!(glob_match("*b*.md", "foobar.md"));
-
-    assert!(!glob_match("a!!b", "a"));
-    assert!(!glob_match("a!!b", "aa"));
-    assert!(!glob_match("a!!b", "a/b"));
-    assert!(!glob_match("a!!b", "a!b"));
-    assert!(glob_match("a!!b", "a!!b"));
-    assert!(!glob_match("a!!b", "a/!!/b"));
-
-    assert!(!glob_match("!a/b", "a/b"));
-    assert!(glob_match("!a/b", "a"));
-    assert!(glob_match("!a/b", "a.b"));
-    assert!(glob_match("!a/b", "a/a"));
-    assert!(glob_match("!a/b", "a/c"));
-    assert!(glob_match("!a/b", "b/a"));
-    assert!(glob_match("!a/b", "b/b"));
-    assert!(glob_match("!a/b", "b/c"));
-
-    assert!(!glob_match("!abc", "abc"));
-    assert!(glob_match("!!abc", "abc"));
-    assert!(!glob_match("!!!abc", "abc"));
-    assert!(glob_match("!!!!abc", "abc"));
-    assert!(!glob_match("!!!!!abc", "abc"));
-    assert!(glob_match("!!!!!!abc", "abc"));
-    assert!(!glob_match("!!!!!!!abc", "abc"));
-    assert!(glob_match("!!!!!!!!abc", "abc"));
-
-    // assert!(!glob_match("!(*/*)", "a/a"));
-    // assert!(!glob_match("!(*/*)", "a/b"));
-    // assert!(!glob_match("!(*/*)", "a/c"));
-    // assert!(!glob_match("!(*/*)", "b/a"));
-    // assert!(!glob_match("!(*/*)", "b/b"));
-    // assert!(!glob_match("!(*/*)", "b/c"));
-    // assert!(!glob_match("!(*/b)", "a/b"));
-    // assert!(!glob_match("!(*/b)", "b/b"));
-    // assert!(!glob_match("!(a/b)", "a/b"));
-    assert!(!glob_match("!*", "a"));
-    assert!(!glob_match("!*", "a.b"));
-    assert!(!glob_match("!*/*", "a/a"));
-    assert!(!glob_match("!*/*", "a/b"));
-    assert!(!glob_match("!*/*", "a/c"));
-    assert!(!glob_match("!*/*", "b/a"));
-    assert!(!glob_match("!*/*", "b/b"));
-    assert!(!glob_match("!*/*", "b/c"));
-    assert!(!glob_match("!*/b", "a/b"));
-    assert!(!glob_match("!*/b", "b/b"));
-    assert!(!glob_match("!*/c", "a/c"));
-    assert!(!glob_match("!*/c", "a/c"));
-    assert!(!glob_match("!*/c", "b/c"));
-    assert!(!glob_match("!*/c", "b/c"));
-    assert!(!glob_match("!*a*", "bar"));
-    assert!(!glob_match("!*a*", "fab"));
-    // assert!(!glob_match("!a/(*)", "a/a"));
-    // assert!(!glob_match("!a/(*)", "a/b"));
-    // assert!(!glob_match("!a/(*)", "a/c"));
-    // assert!(!glob_match("!a/(b)", "a/b"));
-    assert!(!glob_match("!a/*", "a/a"));
-    assert!(!glob_match("!a/*", "a/b"));
-    assert!(!glob_match("!a/*", "a/c"));
-    assert!(!glob_match("!f*b", "fab"));
-    // assert!(glob_match("!(*/*)", "a"));
-    // assert!(glob_match("!(*/*)", "a.b"));
-    // assert!(glob_match("!(*/b)", "a"));
-    // assert!(glob_match("!(*/b)", "a.b"));
-    // assert!(glob_match("!(*/b)", "a/a"));
-    // assert!(glob_match("!(*/b)", "a/c"));
-    // assert!(glob_match("!(*/b)", "b/a"));
-    // assert!(glob_match("!(*/b)", "b/c"));
-    // assert!(glob_match("!(a/b)", "a"));
-    // assert!(glob_match("!(a/b)", "a.b"));
-    // assert!(glob_match("!(a/b)", "a/a"));
-    // assert!(glob_match("!(a/b)", "a/c"));
-    // assert!(glob_match("!(a/b)", "b/a"));
-    // assert!(glob_match("!(a/b)", "b/b"));
-    // assert!(glob_match("!(a/b)", "b/c"));
-    assert!(glob_match("!*", "a/a"));
-    assert!(glob_match("!*", "a/b"));
-    assert!(glob_match("!*", "a/c"));
-    assert!(glob_match("!*", "b/a"));
-    assert!(glob_match("!*", "b/b"));
-    assert!(glob_match("!*", "b/c"));
-    assert!(glob_match("!*/*", "a"));
-    assert!(glob_match("!*/*", "a.b"));
-    assert!(glob_match("!*/b", "a"));
-    assert!(glob_match("!*/b", "a.b"));
-    assert!(glob_match("!*/b", "a/a"));
-    assert!(glob_match("!*/b", "a/c"));
-    assert!(glob_match("!*/b", "b/a"));
-    assert!(glob_match("!*/b", "b/c"));
-    assert!(glob_match("!*/c", "a"));
-    assert!(glob_match("!*/c", "a.b"));
-    assert!(glob_match("!*/c", "a/a"));
-    assert!(glob_match("!*/c", "a/b"));
-    assert!(glob_match("!*/c", "b/a"));
-    assert!(glob_match("!*/c", "b/b"));
-    assert!(glob_match("!*a*", "foo"));
-    // assert!(glob_match("!a/(*)", "a"));
-    // assert!(glob_match("!a/(*)", "a.b"));
-    // assert!(glob_match("!a/(*)", "b/a"));
-    // assert!(glob_match("!a/(*)", "b/b"));
-    // assert!(glob_match("!a/(*)", "b/c"));
-    // assert!(glob_match("!a/(b)", "a"));
-    // assert!(glob_match("!a/(b)", "a.b"));
-    // assert!(glob_match("!a/(b)", "a/a"));
-    // assert!(glob_match("!a/(b)", "a/c"));
-    // assert!(glob_match("!a/(b)", "b/a"));
-    // assert!(glob_match("!a/(b)", "b/b"));
-    // assert!(glob_match("!a/(b)", "b/c"));
-    assert!(glob_match("!a/*", "a"));
-    assert!(glob_match("!a/*", "a.b"));
-    assert!(glob_match("!a/*", "b/a"));
-    assert!(glob_match("!a/*", "b/b"));
-    assert!(glob_match("!a/*", "b/c"));
-    assert!(glob_match("!f*b", "bar"));
-    assert!(glob_match("!f*b", "foo"));
-
-    assert!(!glob_match("!.md", ".md"));
-    assert!(glob_match("!**/*.md", "a.js"));
-    // assert!(!glob_match("!**/*.md", "b.md"));
-    assert!(glob_match("!**/*.md", "c.txt"));
-    assert!(glob_match("!*.md", "a.js"));
-    assert!(!glob_match("!*.md", "b.md"));
-    assert!(glob_match("!*.md", "c.txt"));
-    assert!(!glob_match("!*.md", "abc.md"));
-    assert!(glob_match("!*.md", "abc.txt"));
-    assert!(!glob_match("!*.md", "foo.md"));
-    assert!(glob_match("!.md", "foo.md"));
-
-    assert!(glob_match("!*.md", "a.js"));
-    assert!(glob_match("!*.md", "b.txt"));
-    assert!(!glob_match("!*.md", "c.md"));
-    assert!(!glob_match("!a/*/a.js", "a/a/a.js"));
-    assert!(!glob_match("!a/*/a.js", "a/b/a.js"));
-    assert!(!glob_match("!a/*/a.js", "a/c/a.js"));
-    assert!(!glob_match("!a/*/*/a.js", "a/a/a/a.js"));
-    assert!(glob_match("!a/*/*/a.js", "b/a/b/a.js"));
-    assert!(glob_match("!a/*/*/a.js", "c/a/c/a.js"));
-    assert!(!glob_match("!a/a*.txt", "a/a.txt"));
-    assert!(glob_match("!a/a*.txt", "a/b.txt"));
-    assert!(glob_match("!a/a*.txt", "a/c.txt"));
-    assert!(!glob_match("!a.a*.txt", "a.a.txt"));
-    assert!(glob_match("!a.a*.txt", "a.b.txt"));
-    assert!(glob_match("!a.a*.txt", "a.c.txt"));
-    assert!(!glob_match("!a/*.txt", "a/a.txt"));
-    assert!(!glob_match("!a/*.txt", "a/b.txt"));
-    assert!(!glob_match("!a/*.txt", "a/c.txt"));
-
-    assert!(glob_match("!*.md", "a.js"));
-    assert!(glob_match("!*.md", "b.txt"));
-    assert!(!glob_match("!*.md", "c.md"));
-    // assert!(!glob_match("!**/a.js", "a/a/a.js"));
-    // assert!(!glob_match("!**/a.js", "a/b/a.js"));
-    // assert!(!glob_match("!**/a.js", "a/c/a.js"));
-    assert!(glob_match("!**/a.js", "a/a/b.js"));
-    assert!(!glob_match("!a/**/a.js", "a/a/a/a.js"));
-    assert!(glob_match("!a/**/a.js", "b/a/b/a.js"));
-    assert!(glob_match("!a/**/a.js", "c/a/c/a.js"));
-    assert!(glob_match("!**/*.md", "a/b.js"));
-    assert!(glob_match("!**/*.md", "a.js"));
-    assert!(!glob_match("!**/*.md", "a/b.md"));
-    // assert!(!glob_match("!**/*.md", "a.md"));
-    assert!(!glob_match("**/*.md", "a/b.js"));
-    assert!(!glob_match("**/*.md", "a.js"));
-    assert!(glob_match("**/*.md", "a/b.md"));
-    assert!(glob_match("**/*.md", "a.md"));
-    assert!(glob_match("!**/*.md", "a/b.js"));
-    assert!(glob_match("!**/*.md", "a.js"));
-    assert!(!glob_match("!**/*.md", "a/b.md"));
-    // assert!(!glob_match("!**/*.md", "a.md"));
-    assert!(glob_match("!*.md", "a/b.js"));
-    assert!(glob_match("!*.md", "a.js"));
-    assert!(glob_match("!*.md", "a/b.md"));
-    assert!(!glob_match("!*.md", "a.md"));
-    assert!(glob_match("!**/*.md", "a.js"));
-    // assert!(!glob_match("!**/*.md", "b.md"));
-    assert!(glob_match("!**/*.md", "c.txt"));
-  }
-
-  #[test]
-  fn question_mark() {
-    assert!(glob_match("?", "a"));
-    assert!(!glob_match("?", "aa"));
-    assert!(!glob_match("?", "ab"));
-    assert!(!glob_match("?", "aaa"));
-    assert!(!glob_match("?", "abcdefg"));
-
-    assert!(!glob_match("??", "a"));
-    assert!(glob_match("??", "aa"));
-    assert!(glob_match("??", "ab"));
-    assert!(!glob_match("??", "aaa"));
-    assert!(!glob_match("??", "abcdefg"));
-
-    assert!(!glob_match("???", "a"));
-    assert!(!glob_match("???", "aa"));
-    assert!(!glob_match("???", "ab"));
-    assert!(glob_match("???", "aaa"));
-    assert!(!glob_match("???", "abcdefg"));
-
-    assert!(!glob_match("a?c", "aaa"));
-    assert!(glob_match("a?c", "aac"));
-    assert!(glob_match("a?c", "abc"));
-    assert!(!glob_match("ab?", "a"));
-    assert!(!glob_match("ab?", "aa"));
-    assert!(!glob_match("ab?", "ab"));
-    assert!(!glob_match("ab?", "ac"));
-    assert!(!glob_match("ab?", "abcd"));
-    assert!(!glob_match("ab?", "abbb"));
-    assert!(glob_match("a?b", "acb"));
-
-    assert!(!glob_match("a/?/c/?/e.md", "a/bb/c/dd/e.md"));
-    assert!(glob_match("a/??/c/??/e.md", "a/bb/c/dd/e.md"));
-    assert!(!glob_match("a/??/c.md", "a/bbb/c.md"));
-    assert!(glob_match("a/?/c.md", "a/b/c.md"));
-    assert!(glob_match("a/?/c/?/e.md", "a/b/c/d/e.md"));
-    assert!(!glob_match("a/?/c/???/e.md", "a/b/c/d/e.md"));
-    assert!(glob_match("a/?/c/???/e.md", "a/b/c/zzz/e.md"));
-    assert!(!glob_match("a/?/c.md", "a/bb/c.md"));
-    assert!(glob_match("a/??/c.md", "a/bb/c.md"));
-    assert!(glob_match("a/???/c.md", "a/bbb/c.md"));
-    assert!(glob_match("a/????/c.md", "a/bbbb/c.md"));
-  }
-
-  #[test]
-  fn braces() {
-    assert!(glob_match("{a,b,c}", "a"));
-    assert!(glob_match("{a,b,c}", "b"));
-    assert!(glob_match("{a,b,c}", "c"));
-    assert!(!glob_match("{a,b,c}", "aa"));
-    assert!(!glob_match("{a,b,c}", "bb"));
-    assert!(!glob_match("{a,b,c}", "cc"));
-
-    assert!(glob_match("a/{a,b}", "a/a"));
-    assert!(glob_match("a/{a,b}", "a/b"));
-    assert!(!glob_match("a/{a,b}", "a/c"));
-    assert!(!glob_match("a/{a,b}", "b/b"));
-    assert!(!glob_match("a/{a,b,c}", "b/b"));
-    assert!(glob_match("a/{a,b,c}", "a/c"));
-    assert!(glob_match("a{b,bc}.txt", "abc.txt"));
-
-    assert!(glob_match("foo[{a,b}]baz", "foo{baz"));
-
-    assert!(!glob_match("a{,b}.txt", "abc.txt"));
-    assert!(!glob_match("a{a,b,}.txt", "abc.txt"));
-    assert!(!glob_match("a{b,}.txt", "abc.txt"));
-    assert!(glob_match("a{,b}.txt", "a.txt"));
-    assert!(glob_match("a{b,}.txt", "a.txt"));
-    assert!(glob_match("a{a,b,}.txt", "aa.txt"));
-    assert!(glob_match("a{a,b,}.txt", "aa.txt"));
-    assert!(glob_match("a{,b}.txt", "ab.txt"));
-    assert!(glob_match("a{b,}.txt", "ab.txt"));
-
-    // assert!(glob_match("{a/,}a/**", "a"));
-    assert!(glob_match("a{a,b/}*.txt", "aa.txt"));
-    assert!(glob_match("a{a,b/}*.txt", "ab/.txt"));
-    assert!(glob_match("a{a,b/}*.txt", "ab/a.txt"));
-    // assert!(glob_match("{a/,}a/**", "a/"));
-    assert!(glob_match("{a/,}a/**", "a/a/"));
-    // assert!(glob_match("{a/,}a/**", "a/a"));
-    assert!(glob_match("{a/,}a/**", "a/a/a"));
-    assert!(glob_match("{a/,}a/**", "a/a/"));
-    assert!(glob_match("{a/,}a/**", "a/a/a/"));
-    assert!(glob_match("{a/,}b/**", "a/b/a/"));
-    assert!(glob_match("{a/,}b/**", "b/a/"));
-    assert!(glob_match("a{,/}*.txt", "a.txt"));
-    assert!(glob_match("a{,/}*.txt", "ab.txt"));
-    assert!(glob_match("a{,/}*.txt", "a/b.txt"));
-    assert!(glob_match("a{,/}*.txt", "a/ab.txt"));
-
-    assert!(glob_match("a{,.*{foo,db},\\(bar\\)}.txt", "a.txt"));
-    assert!(!glob_match("a{,.*{foo,db},\\(bar\\)}.txt", "adb.txt"));
-    assert!(glob_match("a{,.*{foo,db},\\(bar\\)}.txt", "a.db.txt"));
-
-    assert!(glob_match("a{,*.{foo,db},\\(bar\\)}.txt", "a.txt"));
-    assert!(!glob_match("a{,*.{foo,db},\\(bar\\)}.txt", "adb.txt"));
-    assert!(glob_match("a{,*.{foo,db},\\(bar\\)}.txt", "a.db.txt"));
-
-    // assert!(glob_match("a{,.*{foo,db},\\(bar\\)}", "a"));
-    assert!(!glob_match("a{,.*{foo,db},\\(bar\\)}", "adb"));
-    assert!(glob_match("a{,.*{foo,db},\\(bar\\)}", "a.db"));
-
-    // assert!(glob_match("a{,*.{foo,db},\\(bar\\)}", "a"));
-    assert!(!glob_match("a{,*.{foo,db},\\(bar\\)}", "adb"));
-    assert!(glob_match("a{,*.{foo,db},\\(bar\\)}", "a.db"));
-
-    assert!(!glob_match("{,.*{foo,db},\\(bar\\)}", "a"));
-    assert!(!glob_match("{,.*{foo,db},\\(bar\\)}", "adb"));
-    assert!(!glob_match("{,.*{foo,db},\\(bar\\)}", "a.db"));
-    assert!(glob_match("{,.*{foo,db},\\(bar\\)}", ".db"));
-
-    assert!(!glob_match("{,*.{foo,db},\\(bar\\)}", "a"));
-    assert!(glob_match("{*,*.{foo,db},\\(bar\\)}", "a"));
-    assert!(!glob_match("{,*.{foo,db},\\(bar\\)}", "adb"));
-    assert!(glob_match("{,*.{foo,db},\\(bar\\)}", "a.db"));
-
-    assert!(!glob_match("a/b/**/c{d,e}/**/xyz.md", "a/b/c/xyz.md"));
-    assert!(!glob_match("a/b/**/c{d,e}/**/xyz.md", "a/b/d/xyz.md"));
-    assert!(glob_match("a/b/**/c{d,e}/**/xyz.md", "a/b/cd/xyz.md"));
-    assert!(glob_match("a/b/**/{c,d,e}/**/xyz.md", "a/b/c/xyz.md"));
-    assert!(glob_match("a/b/**/{c,d,e}/**/xyz.md", "a/b/d/xyz.md"));
-    assert!(glob_match("a/b/**/{c,d,e}/**/xyz.md", "a/b/e/xyz.md"));
-
-    assert!(glob_match("*{a,b}*", "xax"));
-    assert!(glob_match("*{a,b}*", "xxax"));
-    assert!(glob_match("*{a,b}*", "xbx"));
-
-    assert!(glob_match("*{*a,b}", "xba"));
-    assert!(glob_match("*{*a,b}", "xb"));
-
-    assert!(!glob_match("*??", "a"));
-    assert!(!glob_match("*???", "aa"));
-    assert!(glob_match("*???", "aaa"));
-    assert!(!glob_match("*****??", "a"));
-    assert!(!glob_match("*****???", "aa"));
-    assert!(glob_match("*****???", "aaa"));
-
-    assert!(!glob_match("a*?c", "aaa"));
-    assert!(glob_match("a*?c", "aac"));
-    assert!(glob_match("a*?c", "abc"));
-
-    assert!(glob_match("a**?c", "abc"));
-    assert!(!glob_match("a**?c", "abb"));
-    assert!(glob_match("a**?c", "acc"));
-    assert!(glob_match("a*****?c", "abc"));
-
-    assert!(glob_match("*****?", "a"));
-    assert!(glob_match("*****?", "aa"));
-    assert!(glob_match("*****?", "abc"));
-    assert!(glob_match("*****?", "zzz"));
-    assert!(glob_match("*****?", "bbb"));
-    assert!(glob_match("*****?", "aaaa"));
-
-    assert!(!glob_match("*****??", "a"));
-    assert!(glob_match("*****??", "aa"));
-    assert!(glob_match("*****??", "abc"));
-    assert!(glob_match("*****??", "zzz"));
-    assert!(glob_match("*****??", "bbb"));
-    assert!(glob_match("*****??", "aaaa"));
-
-    assert!(!glob_match("?*****??", "a"));
-    assert!(!glob_match("?*****??", "aa"));
-    assert!(glob_match("?*****??", "abc"));
-    assert!(glob_match("?*****??", "zzz"));
-    assert!(glob_match("?*****??", "bbb"));
-    assert!(glob_match("?*****??", "aaaa"));
-
-    assert!(glob_match("?*****?c", "abc"));
-    assert!(!glob_match("?*****?c", "abb"));
-    assert!(!glob_match("?*****?c", "zzz"));
-
-    assert!(glob_match("?***?****c", "abc"));
-    assert!(!glob_match("?***?****c", "bbb"));
-    assert!(!glob_match("?***?****c", "zzz"));
-
-    assert!(glob_match("?***?****?", "abc"));
-    assert!(glob_match("?***?****?", "bbb"));
-    assert!(glob_match("?***?****?", "zzz"));
-
-    assert!(glob_match("?***?****", "abc"));
-    assert!(glob_match("*******c", "abc"));
-    assert!(glob_match("*******?", "abc"));
-    assert!(glob_match("a*cd**?**??k", "abcdecdhjk"));
-    assert!(glob_match("a**?**cd**?**??k", "abcdecdhjk"));
-    assert!(glob_match("a**?**cd**?**??k***", "abcdecdhjk"));
-    assert!(glob_match("a**?**cd**?**??***k", "abcdecdhjk"));
-    assert!(glob_match("a**?**cd**?**??***k**", "abcdecdhjk"));
-    assert!(glob_match("a****c**?**??*****", "abcdecdhjk"));
-
-    assert!(!glob_match("a/?/c/?/*/e.md", "a/b/c/d/e.md"));
-    assert!(glob_match("a/?/c/?/*/e.md", "a/b/c/d/e/e.md"));
-    assert!(glob_match("a/?/c/?/*/e.md", "a/b/c/d/efghijk/e.md"));
-    assert!(glob_match("a/?/**/e.md", "a/b/c/d/efghijk/e.md"));
-    assert!(!glob_match("a/?/e.md", "a/bb/e.md"));
-    assert!(glob_match("a/??/e.md", "a/bb/e.md"));
-    assert!(!glob_match("a/?/**/e.md", "a/bb/e.md"));
-    assert!(glob_match("a/?/**/e.md", "a/b/ccc/e.md"));
-    assert!(glob_match("a/*/?/**/e.md", "a/b/c/d/efghijk/e.md"));
-    assert!(glob_match("a/*/?/**/e.md", "a/b/c/d/efgh.ijk/e.md"));
-    assert!(glob_match("a/*/?/**/e.md", "a/b.bb/c/d/efgh.ijk/e.md"));
-    assert!(glob_match("a/*/?/**/e.md", "a/bbb/c/d/efgh.ijk/e.md"));
-
-    assert!(glob_match("a/*/ab??.md", "a/bbb/abcd.md"));
-    assert!(glob_match("a/bbb/ab??.md", "a/bbb/abcd.md"));
-    assert!(glob_match("a/bbb/ab???md", "a/bbb/abcd.md"));
-  }
-
-  #[test]
-  fn captures() {
-    fn test_captures<'a>(glob: &str, path: &'a str) -> Option<Vec<&'a str>> {
-      glob_match_with_captures(glob, path)
-        .map(|v| v.into_iter().map(|capture| &path[capture]).collect())
-    }
-
-    assert_eq!(test_captures("a/b", "a/b"), Some(vec![]));
-    assert_eq!(test_captures("a/*/c", "a/bx/c"), Some(vec!["bx"]));
-    assert_eq!(test_captures("a/*/c", "a/test/c"), Some(vec!["test"]));
-    assert_eq!(
-      test_captures("a/*/c/*/e", "a/b/c/d/e"),
-      Some(vec!["b", "d"])
-    );
-    assert_eq!(
-      test_captures("a/*/c/*/e", "a/b/c/d/e"),
-      Some(vec!["b", "d"])
-    );
-    assert_eq!(test_captures("a/{b,x}/c", "a/b/c"), Some(vec!["b"]));
-    assert_eq!(test_captures("a/{b,x}/c", "a/x/c"), Some(vec!["x"]));
-    assert_eq!(test_captures("a/?/c", "a/b/c"), Some(vec!["b"]));
-    assert_eq!(test_captures("a/*?x/c", "a/yybx/c"), Some(vec!["yy", "b"]));
-    assert_eq!(
-      test_captures("a/*[a-z]x/c", "a/yybx/c"),
-      Some(vec!["yy", "b"])
-    );
-    assert_eq!(
-      test_captures("a/{b*c,c}y", "a/bdcy"),
-      Some(vec!["bdc", "d"])
-    );
-    assert_eq!(test_captures("a/{b*,c}y", "a/bdy"), Some(vec!["bd", "d"]));
-    assert_eq!(test_captures("a/{b*c,c}", "a/bdc"), Some(vec!["bdc", "d"]));
-    assert_eq!(test_captures("a/{b*,c}", "a/bd"), Some(vec!["bd", "d"]));
-    assert_eq!(test_captures("a/{b*,c}", "a/c"), Some(vec!["c", ""]));
-    assert_eq!(
-      test_captures("a/{b{c,d},c}y", "a/bdy"),
-      Some(vec!["bd", "d"])
-    );
-    assert_eq!(
-      test_captures("a/{b*,c*}y", "a/bdy"),
-      Some(vec!["bd", "d", ""])
-    );
-    assert_eq!(
-      test_captures("a/{b*,c*}y", "a/cdy"),
-      Some(vec!["cd", "", "d"])
-    );
-    assert_eq!(test_captures("a/{b,c}", "a/b"), Some(vec!["b"]));
-    assert_eq!(test_captures("a/{b,c}", "a/c"), Some(vec!["c"]));
-    assert_eq!(test_captures("a/{b,c[}]*}", "a/b"), Some(vec!["b", "", ""]));
-    assert_eq!(
-      test_captures("a/{b,c[}]*}", "a/c}xx"),
-      Some(vec!["c}xx", "}", "xx"])
-    );
-
-    // assert\.deepEqual\(([!])?capture\('(.*?)', ['"](.*?)['"]\), (.*)?\);
-    // assert_eq!(test_captures("$2", "$3"), Some(vec!$4));
-
-    assert_eq!(test_captures("test/*", "test/foo"), Some(vec!["foo"]));
-    assert_eq!(
-      test_captures("test/*/bar", "test/foo/bar"),
-      Some(vec!["foo"])
-    );
-    assert_eq!(
-      test_captures("test/*/bar/*", "test/foo/bar/baz"),
-      Some(vec!["foo", "baz"])
-    );
-    assert_eq!(test_captures("test/*.js", "test/foo.js"), Some(vec!["foo"]));
-    assert_eq!(
-      test_captures("test/*-controller.js", "test/foo-controller.js"),
-      Some(vec!["foo"])
-    );
-
-    assert_eq!(
-      test_captures("test/**/*.js", "test/a.js"),
-      Some(vec!["", "a"])
-    );
-    assert_eq!(
-      test_captures("test/**/*.js", "test/dir/a.js"),
-      Some(vec!["dir", "a"])
-    );
-    assert_eq!(
-      test_captures("test/**/*.js", "test/dir/test/a.js"),
-      Some(vec!["dir/test", "a"])
-    );
-    assert_eq!(
-      test_captures("**/*.js", "test/dir/a.js"),
-      Some(vec!["test/dir", "a"])
-    );
-    assert_eq!(
-      test_captures("**/**/**/**/a", "foo/bar/baz/a"),
-      Some(vec!["foo/bar/baz"])
-    );
-    assert_eq!(
-      test_captures("a/{b/**/y,c/**/d}", "a/b/y"),
-      Some(vec!["b/y", "", ""])
-    );
-    assert_eq!(
-      test_captures("a/{b/**/y,c/**/d}", "a/b/x/x/y"),
-      Some(vec!["b/x/x/y", "x/x", ""])
-    );
-    assert_eq!(
-      test_captures("a/{b/**/y,c/**/d}", "a/c/x/x/d"),
-      Some(vec!["c/x/x/d", "", "x/x"])
-    );
-    assert_eq!(
-      test_captures("a/{b/**/**/y,c/**/**/d}", "a/b/x/x/x/x/x/y"),
-      Some(vec!["b/x/x/x/x/x/y", "x/x/x/x/x", ""])
-    );
-    assert_eq!(
-      test_captures("a/{b/**/**/y,c/**/**/d}", "a/c/x/x/x/x/x/d"),
-      Some(vec!["c/x/x/x/x/x/d", "", "x/x/x/x/x"])
-    );
-    assert_eq!(
-      test_captures(
-        "some/**/{a,b,c}/**/needle.txt",
-        "some/path/a/to/the/needle.txt"
-      ),
-      Some(vec!["path", "a", "to/the"])
+  #[test_case("a*", "a")]
+  #[test_case("a*", "ab")]
+  #[test_case("a*", "abc")]
+  #[test_case("\\a*", "a" ; "escaped character")]
+  #[test_case("\\a*", "abc" ; "escaped character 2")]
+  #[test_case("\\a*", "abd")]
+  #[test_case("\\a*", "abe")]
+  fn bash(glob: &str, path: &str) {
+    assert!(
+      glob_match(glob, path),
+      "`{}` doesn't match `{}`",
+      path,
+      glob
     );
   }
 
-  #[test]
-  fn fuzz_tests() {
-    // https://github.com/devongovett/glob-match/issues/1
-    let s = "{*{??*{??**,Uz*zz}w**{*{**a,z***b*[!}w??*azzzzzzzz*!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!z[za,z&zz}w**z*z*}";
-    assert!(!glob_match(s, s));
-    let s = "**** *{*{??*{??***\u{5} *{*{??*{??***\u{5},\0U\0}]*****\u{1},\0***\0,\0\0}w****,\0U\0}]*****\u{1},\0***\0,\0\0}w*****\u{1}***{}*.*\0\0*\0";
-    assert!(!glob_match(s, s));
+  #[test_case("a*", "*" ; "wildcard")]
+  #[test_case("a*", "**" ; "wildcard 2")]
+  #[test_case("a*", "\\*" ; "escaped wildcard")]
+  #[test_case("a*", "a/*" ; "wildcard with slash")]
+  #[test_case("a*", "b" ; "wildcard missing")]
+  #[test_case("a*", "bc")]
+  #[test_case("a*", "bcd" ; "wildcard missing 2")]
+  #[test_case("a*", "bdir/" ; "wildcard missing 3")]
+  #[test_case("a*", "Beware" ; "wildcard missing 4")]
+  #[test_case("\\a*", "*" ; "escaped character wildcard")]
+  #[test_case("\\a*", "**" ; "escaped character wildcard 2")]
+  #[test_case("\\a*", "\\*" ; "escaped character escaped wildcard")]
+  #[test_case("\\a*", "a/*" ; "escaped character wildcard with slash")]
+  #[test_case("\\a*", "b"; "escaped character wildcard missing")]
+  #[test_case("\\a*", "bb")]
+  #[test_case("\\a*", "bcd" ; "escaped character wildcard missing 2")]
+  #[test_case("\\a*", "bdir/"; "escaped character wildcard missing 3")]
+  #[test_case("\\a*", "Beware" ; "escaped character wildcard missing 4")]
+  #[test_case("\\a*", "c")]
+  #[test_case("\\a*", "ca")]
+  #[test_case("\\a*", "cb")]
+  #[test_case("\\a*", "d")]
+  #[test_case("\\a*", "dd")]
+  #[test_case("\\a*", "de")]
+  fn bash_not(glob: &str, path: &str) {
+    assert!(!glob_match(glob, path), "`{}` matches `{}`", path, glob);
+  }
+
+  #[test_case("b*/", "bdir/")]
+  fn bash_directories(glob: &str, path: &str) {
+    assert!(
+      glob_match(glob, path),
+      "`{}` doesn't match `{}`",
+      path,
+      glob
+    );
+  }
+
+  #[test_case("b*/", "*" ; "b_star_slash_star")]
+  #[test_case("b*/", "**" ; "b_star_slash_double_star")]
+  #[test_case("b*/", "\\*" ; "b_star_slash_escaped_star")]
+  #[test_case("b*/", "a" ; "b_star_slash_a")]
+  #[test_case("b*/", "a/*" ; "b_star_slash_a_slash_star")]
+  #[test_case("b*/", "abc")]
+  #[test_case("b*/", "abd")]
+  #[test_case("b*/", "abe")]
+  #[test_case("b*/", "b")]
+  #[test_case("b*/", "bb")]
+  #[test_case("b*/", "bcd")]
+  #[test_case("b*/", "Beware")]
+  #[test_case("b*/", "c")]
+  #[test_case("b*/", "ca")]
+  #[test_case("b*/", "cb")]
+  #[test_case("b*/", "d")]
+  #[test_case("b*/", "dd")]
+  #[test_case("b*/", "de")]
+  fn bash_directories_not(glob: &str, path: &str) {
+    assert!(!glob_match(glob, path), "`{}` matches `{}`", path, glob);
+  }
+
+  #[test_case("\\*", "*" ; "escaped star")]
+  #[test_case("*q*", "aqa")]
+  #[test_case("*q*", "aaqaa")]
+  #[test_case("\\**", "*" ; "escaped double star")]
+  #[test_case("\\**", "**" ; "escaped double star 2")]
+  fn bash_escaping(glob: &str, path: &str) {
+    assert!(
+      glob_match(glob, path),
+      "`{}` doesn't match `{}`",
+      path,
+      glob
+    );
+  }
+
+  #[test_case("\\^", "*" ; "escaped caret")]
+  #[test_case("\\^", "**" ; "escaped caret 2")]
+  #[test_case("\\^", "a" ; "escaped caret 4")]
+  #[test_case("\\^", "\\*" ; "escaped caret 3")]
+  #[test_case("\\^", "a/*" ; "escaped caret 5")]
+  #[test_case("\\^", "abc" ; "escaped caret 6")]
+  #[test_case("\\^", "abd" ; "escaped caret 7")]
+  #[test_case("\\^", "abe" ; "escaped caret 8")]
+  #[test_case("\\^", "b" ; "escaped caret 9")]
+  #[test_case("\\^", "bb" ; "escaped caret 10")]
+  #[test_case("\\^", "bcd" ; "escaped caret 11")]
+  #[test_case("\\^", "bdir/" ; "escaped caret 12")]
+  #[test_case("\\^", "Beware" ; "escaped caret 13")]
+  #[test_case("\\^", "c" ; "escaped caret 14")]
+  #[test_case("\\^", "ca" ; "escaped caret 15")]
+  #[test_case("\\^", "cb" ; "escaped caret 16")]
+  #[test_case("\\^", "d" ; "escaped caret 17")]
+  #[test_case("\\^", "dd" ; "escaped caret 18")]
+  #[test_case("\\^", "de" ; "escaped caret 19")]
+  // #[test_case("\\*", "\\*")]
+  #[test_case("\\*", "**")]
+  #[test_case("\\*", "a" ; "escaped star 2")]
+  #[test_case("\\*", "a/*" ; "escaped star 3")]
+  #[test_case("\\*", "abc")]
+  #[test_case("\\*", "abd")]
+  #[test_case("\\*", "abe")]
+  #[test_case("\\*", "b")]
+  #[test_case("\\*", "bb" ; "escaped star 4")]
+  #[test_case("\\*", "bcd" ; "escaped star 5")]
+  #[test_case("\\*", "bdir/" ; "escaped star 6")]
+  #[test_case("\\*", "Beware" ; "escaped star 7")]
+  #[test_case("\\*", "c" ; "escaped star 8")]
+  #[test_case("\\*", "ca" ; "escaped star 9")]
+  #[test_case("\\*", "cb" ; "escaped star 10")]
+  #[test_case("\\*", "d" ; "escaped star 11")]
+  #[test_case("\\*", "dd" ; "escaped star 12")]
+  #[test_case("\\*", "de" ; "escaped star 13")]
+  #[test_case("a\\*", "*" ; "escaped character wildcard missing")]
+  #[test_case("a\\*", "**" ; "escaped character wildcard missing 2")]
+  #[test_case("a\\*", "\\*" ; "escaped character wildcard missing 3")]
+  #[test_case("a\\*", "a" ; "escaped character wildcard missing 4")]
+  #[test_case("a\\*", "a/*" ; "escaped character wildcard missing 5")]
+  #[test_case("a\\*", "abc")]
+  #[test_case("a\\*", "abd")]
+  #[test_case("a\\*", "abe")]
+  #[test_case("a\\*", "b")]
+  #[test_case("a\\*", "bb")]
+  #[test_case("a\\*", "bcd")]
+  #[test_case("a\\*", "bdir/")]
+  #[test_case("a\\*", "Beware")]
+  #[test_case("a\\*", "c")]
+  #[test_case("a\\*", "ca")]
+  #[test_case("a\\*", "cb")]
+  #[test_case("a\\*", "d")]
+  #[test_case("a\\*", "dd")]
+  #[test_case("a\\*", "de")]
+  #[test_case("*q*", "*" ; "missing character wildcard")]
+  #[test_case("*q*", "**" ; "missing character wildcard 2")]
+  #[test_case("*q*", "\\*" ; "missing character wildcard 3")]
+  #[test_case("*q*", "a" ; "missing character wildcard 4")]
+  #[test_case("*q*", "a/*" ; "missing character wildcard 5")]
+  #[test_case("*q*", "abc")]
+  #[test_case("*q*", "abd")]
+  #[test_case("*q*", "abe")]
+  #[test_case("*q*", "b")]
+  #[test_case("*q*", "bb")]
+  #[test_case("*q*", "bcd")]
+  #[test_case("*q*", "bdir/")]
+  #[test_case("*q*", "Beware")]
+  #[test_case("*q*", "c")]
+  #[test_case("*q*", "ca")]
+  #[test_case("*q*", "cb")]
+  #[test_case("*q*", "d")]
+  #[test_case("*q*", "dd")]
+  #[test_case("*q*", "de")]
+  #[test_case("\\**", "\\*" ; "escaped double star missing")]
+  #[test_case("\\**", "a" ; "escaped double star missing 2")]
+  #[test_case("\\**", "a/*" ; "escaped double star missing 3")]
+  #[test_case("\\**", "abc" ; "escaped double star missing 4")]
+  #[test_case("\\**", "abd" ; "escaped double star missing 5")]
+  #[test_case("\\**", "abe" ; "escaped double star missing 6")]
+  #[test_case("\\**", "b" ; "escaped double star missing 7")]
+  #[test_case("\\**", "bb")]
+  #[test_case("\\**", "bcd")]
+  #[test_case("\\**", "bdir/")]
+  #[test_case("\\**", "Beware")]
+  #[test_case("\\**", "c")]
+  #[test_case("\\**", "ca")]
+  #[test_case("\\**", "cb")]
+  #[test_case("\\**", "d")]
+  #[test_case("\\**", "dd")]
+  #[test_case("\\**", "de")]
+  fn bash_escaping_not(glob: &str, path: &str) {
+    assert!(!glob_match(glob, path), "`{}` matches `{}`", path, glob);
+  }
+
+  #[test_case("a*[^c]", "abd")]
+  #[test_case("a*[^c]", "abe")]
+  #[test_case("a[X-]b", "a-b")]
+  #[test_case("a[X-]b", "aXb")]
+  #[test_case("[a-y]*[^c]", "a*")]
+  #[test_case("[a-y]*[^c]", "a123b")]
+  #[test_case("[a-y]*[^c]", "ab")]
+  #[test_case("[a-y]*[^c]", "abd")]
+  #[test_case("[a-y]*[^c]", "abe")]
+  #[test_case("[a-y]*[^c]", "bd")]
+  #[test_case("[a-y]*[^c]", "bb")]
+  #[test_case("[a-y]*[^c]", "bcd")]
+  #[test_case("[a-y]*[^c]", "bdir/")]
+  #[test_case("[a-y]*[^c]", "ca")]
+  #[test_case("[a-y]*[^c]", "cb")]
+  #[test_case("[a-y]*[^c]", "dd")]
+  #[test_case("[a-y]*[^c]", "dd" ; "dd 1")]
+  #[test_case("[a-y]*[^c]", "dd" ; "dd 2")]
+  #[test_case("[a-y]*[^c]", "de")]
+  #[test_case("[a-y]*[^c]", "baz")]
+  #[test_case("[a-y]*[^c]", "bzz" ; "bzz 1")]
+  #[test_case("[a-y]*[^c]", "bzz" ; "bzz 2")]
+  #[test_case("[a-y]*[^c]", "beware")]
+  #[test_case("a\\*b/*", "a*b/ooo")]
+  #[test_case("a\\*?/*", "a*b/ooo")]
+  #[test_case("a[b]c", "abc")]
+  #[test_case("a[\"b\"]c", "abc" ; "abc 1")]
+  #[test_case("a[\\\\b]c", "abc" ; "abc 2")]
+  #[test_case("a[b-d]c", "abc")]
+  #[test_case("a?c", "abc")]
+  #[test_case("*/man*/bash.*", "man/man1/bash.1")]
+  #[test_case("[^a-c]*", "*" ; "ac 1")]
+  #[test_case("[^a-c]*", "**" ; "ac 2")]
+  #[test_case("[^a-c]*", "Beware" ; "beware 1")]
+  #[test_case("[^a-c]*", "Beware" ; "beware 2")]
+  #[test_case("[^a-c]*", "d")]
+  #[test_case("[^a-c]*", "dd")]
+  #[test_case("[^a-c]*", "de")]
+  #[test_case("[^a-c]*", "BZZ")]
+  #[test_case("[^a-c]*", "BewAre")]
+  fn bash_classes(glob: &str, path: &str) {
+    assert!(
+      glob_match(glob, path),
+      "`{}` does not match `{}`",
+      path,
+      glob
+    );
+  }
+
+  #[test_case("a*[^c]", "*" ; "ac 1")]
+  #[test_case("a*[^c]", "**" ; "ac 2")]
+  #[test_case("a*[^c]", "\\*" ; "ac 3")]
+  #[test_case("a*[^c]", "a" ; "aca 1")]
+  #[test_case("a*[^c]", "a/*" ; "aca 2")]
+  #[test_case("a*[^c]", "abc" ; "a star not c abc")]
+  #[test_case("a*[^c]", "b" ; "a star not c b")]
+  #[test_case("a*[^c]", "bb" ; "a star not c bb")]
+  #[test_case("a*[^c]", "bcd" ; "a star not c bcd")]
+  #[test_case("a*[^c]", "bdir/" ; "a star not c bdir/")]
+  #[test_case("a*[^c]", "Beware" ; "a star not c beware")]
+  #[test_case("a*[^c]", "c" ; "a star not c c")]
+  #[test_case("a*[^c]", "ca" ; "a star not c ca")]
+  #[test_case("a*[^c]", "cb" ; "a star not c cb")]
+  #[test_case("a*[^c]", "d" ; "a star not c d")]
+  #[test_case("a*[^c]", "dd" ; "a star not c dd")]
+  #[test_case("a*[^c]", "de" ; "a star not c de")]
+  #[test_case("a*[^c]", "baz" ; "a star not c baz")]
+  #[test_case("a*[^c]", "bzz" ; "bzz 1")]
+  #[test_case("a*[^c]", "BZZ" ; "bzz 2")]
+  #[test_case("a*[^c]", "beware" ; "beware 1")]
+  #[test_case("a*[^c]", "BewAre" ; "beware 2")]
+  #[test_case("[a-y]*[^c]", "*" ; "ayc 1")]
+  #[test_case("[a-y]*[^c]", "**" ; "ayc 2")]
+  #[test_case("[a-y]*[^c]", "\\*" ; "ayc 3")]
+  #[test_case("[a-y]*[^c]", "a" ; "ayca 1")]
+  #[test_case("[a-y]*[^c]", "a123c")]
+  #[test_case("[a-y]*[^c]", "a/*" ; "ayca 2")]
+  #[test_case("[a-y]*[^c]", "abc")]
+  #[test_case("[a-y]*[^c]", "b")]
+  #[test_case("[a-y]*[^c]", "Beware" ; "beware 3")]
+  #[test_case("[a-y]*[^c]", "c")]
+  #[test_case("[a-y]*[^c]", "d")]
+  // assert(!isMatch('bzz', '[a-y]*[^c]', { regex: true }));
+  #[test_case("[a-y]*[^c]", "BZZ")]
+  #[test_case("[a-y]*[^c]", "BewAre" ; "beware 4")]
+  #[test_case("a[b]c", "*" ; "abc 1")]
+  #[test_case("a[b]c", "**" ; "abc 2")]
+  #[test_case("a[b]c", "\\*" ; "abc 3")]
+  #[test_case("a[b]c", "a" ; "abca 1")]
+  #[test_case("a[b]c", "a/*" ; "abca 2")]
+  #[test_case("a[b]c", "abd" ; "a oneof b c abd")]
+  #[test_case("a[b]c", "abe" ; "a oneof b c abe")]
+  #[test_case("a[b]c", "b" ; "a oneof b c b")]
+  #[test_case("a[b]c", "bb" ; "a oneof b c bb")]
+  #[test_case("a[b]c", "bcd" ; "a oneof b c bcd")]
+  #[test_case("a[b]c", "bdir/" ; "a oneof b c bdir/")]
+  #[test_case("a[b]c", "Beware" ; "a oneof b c Beware")]
+  #[test_case("a[b]c", "c" ; "a oneof b c c")]
+  #[test_case("a[b]c", "ca" ; "a oneof b c ca")]
+  #[test_case("a[b]c", "cb" ; "a oneof b c cb")]
+  #[test_case("a[b]c", "d" ; "a oneof b c d")]
+  #[test_case("a[b]c", "dd" ; "a oneof b c dd")]
+  #[test_case("a[b]c", "de" ; "a oneof b c de")]
+  #[test_case("a[b]c", "baz" ; "a oneof b c baz")]
+  #[test_case("a[b]c", "bzz" ; "abc bzz 1")]
+  #[test_case("a[b]c", "BZZ" ; "abc bzz 2")]
+  #[test_case("a[b]c", "beware" ; "abc beware 1")]
+  #[test_case("a[b]c", "BewAre" ; "abc beware 2")]
+  #[test_case("a[\"b\"]c", "*" ; "abc 4")]
+  #[test_case("a[\"b\"]c", "**" ; "abc 5")]
+  #[test_case("a[\"b\"]c", "\\*" ; "abc 6")]
+  #[test_case("a[\"b\"]c", "a" ; "abca 3")]
+  #[test_case("a[\"b\"]c", "a/*" ; "abca 4")]
+  #[test_case("a[\"b\"]c", "abd" ; "abd 1")]
+  #[test_case("a[\"b\"]c", "abe" ; "abe 1")]
+  #[test_case("a[\"b\"]c", "b" ; "abcb 1")]
+  #[test_case("a[\"b\"]c", "bb" ; "abcbb 1")]
+  #[test_case("a[\"b\"]c", "bcd" ; "abc bcd 1")]
+  #[test_case("a[\"b\"]c", "bdir/" ; "abc bdir/ 1")]
+  #[test_case("a[\"b\"]c", "Beware" ; "abc beware 3")]
+  #[test_case("a[\"b\"]c", "c" ; "abc c 1")]
+  #[test_case("a[\"b\"]c", "ca" ; "abc ca 1")]
+  #[test_case("a[\"b\"]c", "cb" ; "abc cb 1")]
+  #[test_case("a[\"b\"]c", "d" ; "abc d 1")]
+  #[test_case("a[\"b\"]c", "dd" ; "abc dd 1")]
+  #[test_case("a[\"b\"]c", "de" ; "abc de 1")]
+  #[test_case("a[\"b\"]c", "baz" ; "abc baz 1")]
+  #[test_case("a[\"b\"]c", "bzz" ; "abc bzz 3")]
+  #[test_case("a[\"b\"]c", "BZZ" ; "abc bzz 4")]
+  #[test_case("a[\"b\"]c", "beware" ; "abc beware 4")]
+  #[test_case("a[\"b\"]c", "BewAre" ; "abc beware 5")]
+  #[test_case("a[\\\\b]c", "*" ; "a double escape b c star")]
+  #[test_case("a[\\\\b]c", "**" ; "a double escape b c doublestar")]
+  #[test_case("a[\\\\b]c", "\\*" ; "a double escape b c backslash star")]
+  #[test_case("a[\\\\b]c", "a" ; "a double escape b c a")]
+  #[test_case("a[\\\\b]c", "a/*" ;  "a double escape b c a slash star")]
+  #[test_case("a[\\\\b]c", "abd" ; "a double escape b c abd")]
+  #[test_case("a[\\\\b]c", "abe" ; "a double escape b c abe")]
+  #[test_case("a[\\\\b]c", "b" ; "a double escape b c b")]
+  #[test_case("a[\\\\b]c", "bb" ; "a double escape b c bb")]
+  #[test_case("a[\\\\b]c", "bcd" ; "a double escape b c bcd")]
+  #[test_case("a[\\\\b]c", "bdir/" ; "a double escape b c bdir slash")]
+  #[test_case("a[\\\\b]c", "Beware" ; "a double escape b c Beware 1")]
+  #[test_case("a[\\\\b]c", "c" ; "a double escape b c c")]
+  #[test_case("a[\\\\b]c", "ca" ; "a double escape b c ca")]
+  #[test_case("a[\\\\b]c", "cb" ; "a double escape b c cb")]
+  #[test_case("a[\\\\b]c", "d" ; "a double escape b c d")]
+  #[test_case("a[\\\\b]c", "dd" ; "a double escape b c dd")]
+  #[test_case("a[\\\\b]c", "de" ; "a double escape b c de")]
+  #[test_case("a[\\\\b]c", "baz" ; "a double escape b c baz")]
+  #[test_case("a[\\\\b]c", "bzz" ; "a double escape b c bzz")]
+  #[test_case("a[\\\\b]c", "BZZ" ;  "a double escape b c BZZ 2")]
+  #[test_case("a[\\\\b]c", "beware" ; "a double escape b c beware 2")]
+  #[test_case("a[\\\\b]c", "BewAre" ; "a double escape b c BewAre 3")]
+  #[test_case("a[\\b]c", "*" ; "a escape b c 1")]
+  #[test_case("a[\\b]c", "**" ; "a escape b c 2")]
+  #[test_case("a[\\b]c", "\\*")]
+  #[test_case("a[\\b]c", "a" ; "a escape b c a")]
+  #[test_case("a[\\b]c", "a/*" ; "a escape b c a 2")]
+  #[test_case("a[\\b]c", "abd")]
+  #[test_case("a[\\b]c", "abe")]
+  #[test_case("a[\\b]c", "b")]
+  #[test_case("a[\\b]c", "bb")]
+  #[test_case("a[\\b]c", "bcd")]
+  #[test_case("a[\\b]c", "bdir/")]
+  #[test_case("a[\\b]c", "Beware")]
+  #[test_case("a[\\b]c", "c")]
+  #[test_case("a[\\b]c", "ca")]
+  #[test_case("a[\\b]c", "cb")]
+  #[test_case("a[\\b]c", "d")]
+  #[test_case("a[\\b]c", "dd")]
+  #[test_case("a[\\b]c", "de")]
+  #[test_case("a[\\b]c", "baz")]
+  #[test_case("a[\\b]c", "bzz" ; "a escape b c bzz")]
+  #[test_case("a[\\b]c", "BZZ" ; "a escape b c BZZ 2")]
+  #[test_case("a[\\b]c", "beware" ; "a escape b c beware")]
+  #[test_case("a[\\b]c", "BewAre" ; "a escape b c BewAre 2")]
+  #[test_case("a[b-d]c", "*" ; "a[b-d]c * 1")]
+  #[test_case("a[b-d]c", "**" ; "a[b-d]c * 2")]
+  #[test_case("a[b-d]c", "\\*")]
+  #[test_case("a[b-d]c", "a" ; "a[b-d]c a 1")]
+  #[test_case("a[b-d]c", "a/*" ; "a[b-d]c a/* 2")]
+  #[test_case("a[b-d]c", "abd")]
+  #[test_case("a[b-d]c", "abe")]
+  #[test_case("a[b-d]c", "b")]
+  #[test_case("a[b-d]c", "bb")]
+  #[test_case("a[b-d]c", "bcd")]
+  #[test_case("a[b-d]c", "bdir/")]
+  #[test_case("a[b-d]c", "Beware")]
+  #[test_case("a[b-d]c", "c")]
+  #[test_case("a[b-d]c", "ca")]
+  #[test_case("a[b-d]c", "cb")]
+  #[test_case("a[b-d]c", "d")]
+  #[test_case("a[b-d]c", "dd")]
+  #[test_case("a[b-d]c", "de")]
+  #[test_case("a[b-d]c", "baz")]
+  #[test_case("a[b-d]c", "bzz" ; "a[b-d]c bzz 1")]
+  #[test_case("a[b-d]c", "BZZ" ; "a[b-d]c BZZ 2")]
+  #[test_case("a[b-d]c", "beware" ; "a[b-d]c beware 1")]
+  #[test_case("a[b-d]c", "BewAre" ; "a[b-d]c BewAre 2")]
+  #[test_case("a?c", "*" ; "a qmark c star")]
+  #[test_case("a?c", "**" ;  "a qmark c star star")]
+  #[test_case("a?c", "\\*" ; "a qmark c backslash star")]
+  #[test_case("a?c", "a" ; "a qmark c a")]
+  #[test_case("a?c", "a/*")]
+  #[test_case("a?c", "abd")]
+  #[test_case("a?c", "abe")]
+  #[test_case("a?c", "b")]
+  #[test_case("a?c", "bb")]
+  #[test_case("a?c", "bcd")]
+  #[test_case("a?c", "bdir/")]
+  #[test_case("a?c", "c" ; "a qmark c c")]
+  #[test_case("a?c", "ca")]
+  #[test_case("a?c", "cb")]
+  #[test_case("a?c", "d")]
+  #[test_case("a?c", "dd")]
+  #[test_case("a?c", "de")]
+  #[test_case("a?c", "baz")]
+  #[test_case("a?c", "bzz" ; "a qmark c bzz")]
+  #[test_case("a?c", "BZZ" ; "a qmark c bzz 2")]
+  #[test_case("a?c", "beware")]
+  #[test_case("a?c", "Beware" ; "a qmark c beware 2")]
+  #[test_case("a?c", "BewAre" ; "a qmark c beware 3")]
+  #[test_case("[^a-c]*", "a" ; "not a to c a")]
+  #[test_case("[^a-c]*", "a/*" ; "not a to c a slash star")]
+  #[test_case("[^a-c]*", "abc")]
+  #[test_case("[^a-c]*", "abd" ; "not a to c abd")]
+  #[test_case("[^a-c]*", "abe" ; "not a to c abe")]
+  #[test_case("[^a-c]*", "b" ; "not a to c b")]
+  #[test_case("[^a-c]*", "bb" ; "not a to c bb")]
+  #[test_case("[^a-c]*", "bcd" ; "not a to c bcd")]
+  #[test_case("[^a-c]*", "bdir/" ; "not a to c bdir slash")]
+  #[test_case("[^a-c]*", "c")]
+  #[test_case("[^a-c]*", "ca" ; "not a to c ca")]
+  #[test_case("[^a-c]*", "cb" ; "not a to c cb")]
+  #[test_case("[^a-c]*", "baz" ; "not a to c baz")]
+  #[test_case("[^a-c]*", "bzz")]
+  #[test_case("[^a-c]*", "beware" ; "not a to c beware")]
+  fn bash_classes_not(glob: &str, path: &str) {
+    assert!(!glob_match(glob, path), "`{}` matches `{}`", path, glob);
+  }
+
+  #[test_case("]", "]")]
+  #[test_case("a[]-]b", "a-b" ; "a dash b")]
+  #[test_case("a[]-]b", "a]b" ; "a bracket b")]
+  #[test_case("a[]]b", "a]b")]
+  #[test_case("a[\\]a\\-]b", "aab")]
+  #[test_case("t[a-g]n", "ten")]
+  #[test_case("t[^a-g]n", "ton")]
+  fn bash_wildmatch(glob: &str, path: &str) {
+    assert!(glob_match(glob, path));
+  }
+
+  #[test_case("a[]-]b", "aab")]
+  #[test_case("[ten]", "ten")]
+  fn bash_wildmatch_not(glob: &str, path: &str) {
+    assert!(!glob_match(glob, path), "`{}` matches `{}`", path, glob);
+  }
+
+  #[test_case("foo[/]bar", "foo/bar")]
+  #[test_case("f[^eiu][^eiu][^eiu][^eiu][^eiu]r", "foo-bar")]
+  fn bash_slashmatch(glob: &str, path: &str) {
+    assert!(glob_match(glob, path));
+  }
+
+  // #[test_case("f[^eiu][^eiu][^eiu][^eiu][^eiu]r", "f[^eiu][^eiu][^eiu][^eiu][^eiu]r")]
+  // fn bash_slashmatch_not(glob: &str, path: &str) {
+  //   assert!(!glob_match(glob, path), "`{}` matches `{}`", path, glob);
+  // }
+
+  #[test_case("a**c", "abc" ; "a doublestar")]
+  #[test_case("a***c", "abc" ; "a doublestar star")]
+  #[test_case("a*****?c", "abc")]
+  #[test_case("?*****??", "bbc")]
+  #[test_case("?*****??", "abc")]
+  #[test_case("*****??", "bbc" ; "bbc 2")]
+  #[test_case("*****??", "abc" ; "abc 2")]
+  #[test_case("?*****?c", "bbc" ; "c bbc 2")]
+  #[test_case("?*****?c", "abc" ; "c abc 2")]
+  #[test_case("?***?****c", "bbc")]
+  #[test_case("?***?****c", "abc")]
+  #[test_case("?***?****?", "bbc" ; "bbc 3")]
+  #[test_case("?***?****?", "abc" ; "abc 3")]
+  #[test_case("?***?****", "bbc" ; "bbc 4")]
+  #[test_case("?***?****", "abc" ; "abc 4")]
+  #[test_case("*******c", "bbc" ; "c bbc 3")]
+  #[test_case("*******c", "abc" ; "c abc 3")]
+  #[test_case("*******?", "bbc" ; "bbc 5")]
+  #[test_case("*******?", "abc" ; "abc 5")]
+  #[test_case("a*cd**?**??k", "abcdecdhjk" ; "bash extra stars")]
+  #[test_case("a**?**cd**?**??k", "abcdecdhjk" ; "bash extra stars 2")]
+  #[test_case("a**?**cd**?**??k***", "abcdecdhjk" ; "bash extra stars 3")]
+  #[test_case("a**?**cd**?**??***k", "abcdecdhjk" ; "bash extra stars 4")]
+  #[test_case("a**?**cd**?**??***k**", "abcdecdhjk")]
+  #[test_case("a****c**?**??*****", "abcdecdhjk")]
+  fn bash_extra_stars(glob: &str, path: &str) {
+    assert!(glob_match(glob, path));
+  }
+
+  #[test_case("a**c", "bbc")]
+  #[test_case("a**c", "bbd")]
+  #[test_case("a***c", "bbc" ; "a doublestar star c")]
+  #[test_case("a***c", "bbd" ; "a doublestar star d")]
+  #[test_case("a*****?c", "bbc" ; "a 5 star qmark c")]
+  #[test_case("?***?****c", "bbd")]
+  fn bash_extra_stars_not(glob: &str, path: &str) {
+    assert!(!glob_match(glob, path), "`{}` matches `{}`", path, glob);
+  }
+
+  #[test_case("*.js", "z.js")]
+  #[test_case("z*.js", "z.js")]
+  #[test_case("*/*", "a/z")]
+  #[test_case("*/z*.js", "a/z.js")]
+  #[test_case("a/z*.js", "a/z.js")]
+  #[test_case("*", "ab" ; "star ab")]
+  #[test_case("*", "abc")]
+  #[test_case("*c", "abc")]
+  #[test_case("a*", "abc")]
+  #[test_case("a*c", "abc")]
+  #[test_case("*r", "bar")]
+  #[test_case("b*", "bar")]
+  #[test_case("f*", "foo")]
+  #[test_case("*abc*", "one abc two")]
+  #[test_case("a*b", "a         b")]
+  #[test_case("*a*", "bar")]
+  #[test_case("*abc*", "oneabctwo")]
+  #[test_case("*-*.*-*", "a-b.c-d" ; "10")]
+  #[test_case("*-b*c-*", "a-b.c-d" ; "11")]
+  #[test_case("*-b.c-*", "a-b.c-d" ; "12")]
+  #[test_case("*.*", "a-b.c-d" ; "9")]
+  #[test_case("*.*-*", "a-b.c-d")]
+  #[test_case("*.*-d", "a-b.c-d")]
+  #[test_case("*.c-*", "a-b.c-d")]
+  #[test_case("*b.*d", "a-b.c-d")]
+  #[test_case("a*.c*", "a-b.c-d")]
+  #[test_case("a-*.*-d", "a-b.c-d")]
+  #[test_case("*.*", "a.b" ; "star dot star a.b")]
+  #[test_case("*.b", "a.b")]
+  #[test_case("a.*", "a.b")]
+  #[test_case("**-**.**-**", "a-b.c-d" ; "8")]
+  #[test_case("**-b**c-**", "a-b.c-d" ; "7")]
+  #[test_case("**-b.c-**", "a-b.c-d" ; "6")]
+  #[test_case("**.**", "a-b.c-d" ; "doublestar dot doublestar a-b.c-d")]
+  #[test_case("**.**-**", "a-b.c-d" ; "doublestar dot doublestar dash doublestar a-b.c-d")]
+  #[test_case("**.**-d", "a-b.c-d" ; "5")]
+  #[test_case("**.c-**", "a-b.c-d" ; "4")]
+  #[test_case("**b.**d", "a-b.c-d" ; "3")]
+  #[test_case("a**.c**", "a-b.c-d" ; "2")]
+  #[test_case("a-**.**-d", "a-b.c-d" ; "1")]
+  #[test_case("**.**", "a.b" ; "doublestar dot doublestar a.b")]
+  #[test_case("**.b", "a.b" ; "doublestar dot b a.b")]
+  #[test_case("a.**", "a.b" ; "a dot doublestar a.b")]
+  #[test_case("a.b", "a.b" ; "a dot b a.b")]
+  #[test_case("*/*", "/ab" ; "star slash star /ab")]
+  #[test_case(".", ".")]
+  #[test_case("/*", "/ab" ; "slash star")]
+  #[test_case("/??", "/ab" ; "slash qmark qmark")]
+  #[test_case("/?b", "/ab")]
+  #[test_case("/*", "/cd")]
+  #[test_case("a", "a" ; "basic match")]
+  #[test_case("a/.*", "a/.b" ; "a dot star a/.b")]
+  #[test_case("?/?", "a/b" ; "qmark slash qmark")]
+  #[test_case("a/**/j/**/z/*.md", "a/b/c/d/e/j/n/p/o/z/c.md")]
+  #[test_case("a/**/z/*.md", "a/b/c/d/e/z/c.md")]
+  #[test_case("a/b/c/*.md", "a/b/c/xyz.md")]
+  #[test_case("a/*/z/.a", "a/b/z/.a")]
+  #[test_case("a/**/c/*.md", "a/bb.bb/aa/b.b/aa/c/xyz.md")]
+  #[test_case("a/**/c/*.md", "a/bb.bb/aa/bb/aa/c/xyz.md")]
+  #[test_case("a/*/c/*.md", "a/bb.bb/c/xyz.md")]
+  #[test_case("a/*/c/*.md", "a/bb/c/xyz.md")]
+  #[test_case("a/*/c/*.md", "a/bbbb/c/xyz.md")]
+  #[test_case("*", "aaa")]
+  #[test_case("ab", "ab" ; "ab ab")]
+  #[test_case("*/*/*", "aaa/bba/ccc")]
+  #[test_case("aaa/**", "aaa/bba/ccc")]
+  #[test_case("aaa/*", "aaa/bbb")]
+  #[test_case("*/*z*/*/*i", "ab/zzz/ejkl/hi")]
+  #[test_case("*j*i", "abzzzejklhi")]
+  #[test_case("*", "a" ; "star a")]
+  #[test_case("*", "b" ; "star b")]
+  #[test_case("*/*", "a/a" ; "star star a/a")]
+  #[test_case("*/*/*", "a/a/a" ; "star star star a/a/a")]
+  #[test_case("*/*/*/*", "a/a/a/a")]
+  #[test_case("*/*/*/*/*", "a/a/a/a/a")]
+  #[test_case("a/*", "a/a" ; "a star a")]
+  #[test_case("a/*/*", "a/a/a" ; "a star star a")]
+  #[test_case("a/*/*/*", "a/a/a/a" ; "a star star star a")]
+  #[test_case("a/*/*/*/*", "a/a/a/a/a" ; "a star star star star a")]
+  #[test_case("a/*/a", "a/a/a" ; "a star a a/a/a")]
+  #[test_case("a/*/b", "a/a/b")]
+  #[test_case("*/**/a", "a/a" ; "star doublestar a a/a")]
+  #[test_case("*/**/a", "a/a/a" ; "star doublestar a a/a/a")]
+  #[test_case("*/**/a", "a/a/a/a" ; "star doublestar a a/a/a/a")]
+  #[test_case("*/**/a", "a/a/a/a/a" ; "star doublestar a a/a/a/a/a")]
+  // #[test_case("*", "a/")]
+  #[test_case("*/", "a/" ; "star slash a slash")]
+  #[test_case("*{,/}", "a/" ; "star brace slash a slash")]
+  #[test_case("*/*", "a/a")]
+  #[test_case("a/*", "a/a" ; "a star a/a")]
+  #[test_case("a/**/*.txt", "a/x/y.txt")]
+  #[test_case("a/*.txt", "a/b.txt")]
+  #[test_case("a*.txt", "a.txt")]
+  #[test_case("*.txt", "a.txt")]
+  #[test_case("**/..", "/home/foo/..")]
+  #[test_case("**/a", "a"; "doublestar slash a a")]
+  #[test_case("**", "a/a"; "doublestar a/a")]
+  #[test_case("a/**", "a/a")]
+  #[test_case("a/**", "a/" ; "a doublestar a slash")]
+  // #[test_case("a/**", "a")]
+  // #[test_case("**/a/**", "a")]
+  // #[test_case("a/**", "a")]
+  #[test_case("*/**/a", "a/a" ; "star doublestar a a slash a")]
+  // #[test_case("a/**", "a")]
+  #[test_case("*/**", "foo/" ; "star doublestar foo slash")]
+  #[test_case("**/*", "foo/bar" ; "doublestar star foo/bar")]
+  #[test_case("*/*", "foo/bar" ; "star star foo/bar")]
+  #[test_case("*/**", "foo/bar" ; "star doublestar foo/bar")]
+  #[test_case("**/", "foo/bar/" ; "doublestar foo/bar slash")]
+  // #[test_case("**/*", "foo/bar/")]
+  #[test_case("**/*/", "foo/bar/" ; "doublestar star foo/bar slash")]
+  #[test_case("*/**", "foo/bar/" ; "star doublestar foo/bar slash")]
+  #[test_case("*/*/", "foo/bar/" ; "star star foo/bar slash")]
+  // #[test_case("foo/**", "foo")]
+  #[test_case("/*", "/ab")]
+  #[test_case("/*", "/cd" ; "star /cd")]
+  #[test_case("/*", "/ef")]
+  #[test_case("a/**/j/**/z/*.md", "a/b/j/c/z/x.md")]
+  #[test_case("a/**/j/**/z/*.md", "a/j/z/x.md")]
+  #[test_case("**/foo", "bar/baz/foo")]
+  #[test_case("**/bar/*", "deep/foo/bar/baz" ; "doublestar bar star deep/foo/bar/baz")]
+  #[test_case("**/bar/**", "deep/foo/bar/baz/" ; "doublestar bar doublestar deep/foo/bar/baz")]
+  #[test_case("**/bar/*/*", "deep/foo/bar/baz/x")]
+  #[test_case("foo/**/**/bar", "foo/b/a/z/bar" ; "foo doublestar doublestar bar foo/b/a/z/bar")]
+  #[test_case("foo/**/bar", "foo/b/a/z/bar" ; "foo doublestar bar foo/b/a/z/bar")]
+  #[test_case("foo/**/**/bar", "foo/bar" ; "foo doublestar doublestar bar foo/bar")]
+  #[test_case("foo/**/bar", "foo/bar" ; "foo doublestar bar foo/bar")]
+  #[test_case("*/bar/**", "foo/bar/baz/x")]
+  #[test_case("foo/**/**/bar", "foo/baz/bar" ; "foo doublestar doublestar bar")]
+  #[test_case("foo/**/bar", "foo/baz/bar" ; "foo doublestar bar")]
+  #[test_case("**/foo", "XXX/foo")]
+  fn stars(glob: &str, path: &str) {
+    assert!(glob_match(glob, path))
+  }
+
+  #[test_case("*.js", "a/b/c/z.js")]
+  #[test_case("*.js", "a/b/z.js")]
+  #[test_case("*.js", "a/z.js")]
+  // #[test_case("*/*", "a/.ab")]
+  // #[test_case("*", ".ab")]
+  #[test_case("f*", "bar")]
+  #[test_case("*r", "foo")]
+  #[test_case("b*", "foo")]
+  #[test_case("*", "foo/bar")]
+  #[test_case("*a*", "foo")]
+  #[test_case("*-bc-*", "a-b.c-d" ; "star dash bc dash star a-b.c-d")]
+  #[test_case("**-bc-**", "a-b.c-d" ; "doublestar dash bc dash doublestar a-b.c-d")]
+  #[test_case("a/", "a/.b" ; "a slash a/.b")]
+  #[test_case("bz", "a/b/z/.a")]
+  #[test_case("*/*/*", "aaa" ; "star star star aaa")]
+  #[test_case("*/*/*", "aaa/bb/aa/rr")]
+  #[test_case("aaa*", "aaa/bba/ccc" ; "aaa star aaa/bba/ccc")]
+  // #[test_case("aaa**", "aaa/bba/ccc")]
+  #[test_case("aaa/*", "aaa/bba/ccc" ; "aaa slash star aaa/bba/ccc")]
+  #[test_case("aaa/*ccc", "aaa/bba/ccc")]
+  #[test_case("aaa/*z", "aaa/bba/ccc")]
+  #[test_case("*/*/*", "aaa/bbb")]
+  #[test_case("*/*jk*/*i", "ab/zzz/ejkl/hi")]
+  #[test_case("*", "a/a" ; "star a/a")]
+  #[test_case("*", "a/a/a" ; "star a/a/a")]
+  #[test_case("*", "a/a/b" ; "star a/a/b")]
+  #[test_case("*", "a/a/a/a" ; "star a/a/a/a")]
+  #[test_case("*", "a/a/a/a/a" ; "star a/a/a/a/a")]
+  #[test_case("*/*", "a" ; "star star a")]
+  #[test_case("*/*", "a/a/a" ; "star star a/a/a")]
+  #[test_case("*/*/*", "a" ; "star star star a")]
+  #[test_case("*/*/*", "a/a" ; "star star star a/a")]
+  #[test_case("*/*/*", "a/a/a/a" ; "star star star a/a/a/a")]
+  #[test_case("*/*/*/*", "a" ; "star star star star a")]
+  #[test_case("*/*/*/*", "a/a" ; "star star star star a/a")]
+  #[test_case("*/*/*/*", "a/a/a" ; "star star star star a/a/a")]
+  #[test_case("*/*/*/*", "a/a/a/a/a")]
+  #[test_case("*/*/*/*/*", "a" ; "star star star star star a")]
+  #[test_case("*/*/*/*/*", "a/a" ; "star star star star star a/a")]
+  #[test_case("*/*/*/*/*", "a/a/a" ; "star star star star star a/a/a")]
+  #[test_case("*/*/*/*/*", "a/a/b" ; "star star star star star a/a/b")]
+  #[test_case("*/*/*/*/*", "a/a/a/a" ; "star star star star star a/a/a/a")]
+  #[test_case("*/*/*/*/*", "a/a/a/a/a/a" ; "star star star star star")]
+  #[test_case("a/*", "a" ; "a slash star a")]
+  #[test_case("a/*", "a/a/a" ; "a slash star a/a/a")]
+  #[test_case("a/*", "a/a/a/a" ; "a slash star a/a/a/a")]
+  #[test_case("a/*", "a/a/a/a/a" ; "a slash star")]
+  #[test_case("a/*/*", "a" ; "a slash star slash star a")]
+  #[test_case("a/*/*", "a/a" ; "a slash star slash star a/a")]
+  #[test_case("a/*/*", "b/a/a")]
+  #[test_case("a/*/*", "a/a/a/a" ; "a slash star slash star a/a/a/a")]
+  #[test_case("a/*/*", "a/a/a/a/a" ; "a slash star slash star")]
+  #[test_case("a/*/*/*", "a" ; "a slash star slash star slash star a")]
+  #[test_case("a/*/*/*", "a/a" ; "a slash star slash star slash star a/a")]
+  #[test_case("a/*/*/*", "a/a/a" ; "a slash star slash star slash star a/a/a")]
+  #[test_case("a/*/*/*", "a/a/a/a/a" ; "a slash star slash star slash star")]
+  #[test_case("a/*/*/*/*", "a" ; "a slash star slash star slash star slash star a")]
+  #[test_case("a/*/*/*/*", "a/a" ; "a slash star slash star slash star slash star a/a")]
+  #[test_case("a/*/*/*/*", "a/a/a" ; "a slash star slash star slash star slash star a/a/a")]
+  #[test_case("a/*/*/*/*", "a/a/b")]
+  #[test_case("a/*/*/*/*", "a/a/a/a" ; "a slash star slash star slash star slash star")]
+  #[test_case("a/*/a", "a")]
+  #[test_case("a/*/a", "a/a")]
+  #[test_case("a/*/a", "a/a/b")]
+  #[test_case("a/*/a", "a/a/a/a" ; "a slash star slash a")]
+  #[test_case("a/*/a", "a/a/a/a/a")]
+  #[test_case("a/*/b", "a")]
+  #[test_case("a/*/b", "a/a" ; "a slash star slash b")]
+  #[test_case("a/*/b", "a/a/a")]
+  #[test_case("a/*/b", "a/a/a/a")]
+  #[test_case("a/*/b", "a/a/a/a/a")]
+  #[test_case("*/**/a", "a" ; "star slash doublestar slash a a")]
+  #[test_case("*/**/a", "a/a/b" ; "star slash doublestar slash a a/a/b")]
+  #[test_case("*/", "a" ; "star slash a")]
+  #[test_case("*/*", "a" ; "star slash star a")]
+  // #[test_case("*/*", "a/")]
+  // #[test_case("a/*", "a/")]
+  #[test_case("*/", "a/a" ; "star slash a/a")]
+  #[test_case("*/", "a/x/y" ; "star slash a/x/y")]
+  #[test_case("*/*", "a/x/y" ; "star slash star a/x/y")]
+  #[test_case("a/*", "a/x/y")]
+  #[test_case("a/**/*.txt", "a.txt" ; "a doublestar star .txt")]
+  #[test_case("a/**/*.txt", "a/x/y/z" ; "a slash doublestar star .txt")]
+  #[test_case("a/*.txt", "a.txt" ; "a star .txt")]
+  #[test_case("a/*.txt", "a/x/y.txt" ; "a slash star .txt a/x/y.txt")]
+  #[test_case("a/*.txt", "a/x/y/z" ; "a slash star .txt a/x/y/z")]
+  #[test_case("a*.txt", "a/b.txt")]
+  #[test_case("a*.txt", "a/x/y.txt" ; "a*.txt")]
+  #[test_case("a*.txt", "a/x/y/z")]
+  #[test_case("*.txt", "a/b.txt")]
+  #[test_case("*.txt", "a/x/y.txt")]
+  #[test_case("*.txt", "a/x/y/z")]
+  #[test_case("a*", "a/b")]
+  #[test_case("a/**/b", "a/a/bb")]
+  #[test_case("a/**/b", "a/bb")]
+  #[test_case("*/**", "foo")]
+  #[test_case("**/", "foo/bar" ; "doublestar slash")]
+  #[test_case("**/*/", "foo/bar" ; "doublestar star slash")]
+  #[test_case("*/*/", "foo/bar" ; "star star slash")]
+  #[test_case("**/", "a/a" ; "doublestar slash a/a")]
+  #[test_case("*/foo", "bar/baz/foo")]
+  #[test_case("**/bar/*", "deep/foo/bar")]
+  #[test_case("*/bar/**", "deep/foo/bar/baz/x")]
+  #[test_case("/*", "ef")]
+  #[test_case("foo?bar", "foo/bar")]
+  #[test_case("**/bar*", "foo/bar/baz")]
+  // #[test_case("**/bar**", "foo/bar/baz")]
+  #[test_case("foo**bar", "foo/baz/bar" ; "foo doublestar bar")]
+  #[test_case("foo*bar", "foo/baz/bar" ; "foo star bar")]
+  fn stars_not(glob: &str, path: &str) {
+    assert!(!glob_match(glob, path))
+  }
+
+  #[test_case("**/*.js", "a/b/c/d.js")]
+  #[test_case("**/*.js", "a/b/c.js")]
+  #[test_case("**/*.js", "a/b.js")]
+  #[test_case("a/b/**/*.js", "a/b/c/d/e/f.js")]
+  #[test_case("a/b/**/*.js", "a/b/c/d/e.js")]
+  #[test_case("a/b/c/**/*.js", "a/b/c/d.js" ; "a b c slash doublestar star js")]
+  #[test_case("a/b/**/*.js", "a/b/c/d.js")]
+  #[test_case("a/b/**/*.js", "a/b/d.js")]
+  #[test_case("a/**/b/**/c", "a/b/c/b/c")]
+  #[test_case("a/**b**/c", "a/aba/c")]
+  #[test_case("a/**b**/c", "a/b/c")]
+  #[test_case("a/b/c**/*.js", "a/b/c/d.js" ; "a b c doublestar star js")]
+  #[test_case("**/a", "a" ; "doublestar a a")]
+  // #[test_case("a/**", "a")]
+  #[test_case("**", "a/" ; "doublestar a slash")]
+  #[test_case("**/a/**", "a/" ; "doublestar a doublestar a slash")]
+  #[test_case("a/**", "a/" ; "a doublestar a slash")]
+  #[test_case("a/**/**", "a/" ; "a doublestar doublestar a slash")]
+  #[test_case("**/a", "a/a" ; "doublestar a a/a")]
+  #[test_case("a/**", "a/b" ; "a doublestar a/b")]
+  #[test_case("a/**/**/**/*", "a/b" ; "a doublestar dobulestar dobulestar star a/b")]
+  #[test_case("a/**/b", "a/b" ; "a doublestar b")]
+  #[test_case("**/**", "a/b/c" ; "doublestar doublestar a/b/c")]
+  #[test_case("*/**", "a/b/c" ; "star doublestar a/b/c")]
+  #[test_case("a/**", "a/b/c" ; "a doublestar a/b/c")]
+  #[test_case("a/**/**/*", "a/b/c" ; "a doublestar doublestar star a/b/c")]
+  #[test_case("a/**/**/**/*", "a/b/c" ; "a doublestar dobulestar dobulestar star a/b/c")]
+  #[test_case("a/**", "a/b/c/d" ; "a doublestar")]
+  #[test_case("a/**/*", "a/b/c/d" ; "a doublestar star")]
+  #[test_case("a/**/**/*", "a/b/c/d" ; "a doublestar dobulestar star")]
+  #[test_case("a/**/**/**/*", "a/b/c/d" ; "a doublestar dobulestar dobulestar star")]
+  #[test_case("a/b/**/c/**/*.*", "a/b/c/d.e")]
+  #[test_case("a/**/f/*.md", "a/b/c/d/e/f/g.md")]
+  #[test_case("a/**/f/**/k/*.md", "a/b/c/d/e/f/g/h/i/j/k/l.md")]
+  #[test_case("a/b/c/*.md", "a/b/c/def.md")]
+  #[test_case("a/*/c/*.md", "a/bb.bb/c/ddd.md")]
+  #[test_case("a/**/f/*.md", "a/bb.bb/cc/d.d/ee/f/ggg.md")]
+  #[test_case("a/**/f/*.md", "a/bb.bb/cc/dd/ee/f/ggg.md")]
+  #[test_case("a/*/c/*.md", "a/bb/c/ddd.md")]
+  #[test_case("a/*/c/*.md", "a/bbbb/c/ddd.md")]
+  // #[test_case("a/**", "a")]
+  // #[test_case("a{,/**}", "a")]
+  #[test_case("**", "a/b/c/d" ; "doublestar")]
+  #[test_case("**", "a/b/c/d/" ; "doublestar end slash")]
+  #[test_case("**/**", "a/b/c/d/" ; "doublestar doublestar")]
+  #[test_case("**/b/**", "a/b/c/d/")]
+  #[test_case("a/b/**", "a/b/c/d/" ; "ab doublestar")]
+  #[test_case("a/b/**/", "a/b/c/d/" ; "ab doublestar slash")]
+  #[test_case("a/b/**/c/**/", "a/b/c/d/")]
+  #[test_case("a/b/**/c/**/d/", "a/b/c/d/")]
+  #[test_case("a/b/**/**/*.*", "a/b/c/d/e.f" ; "ab doublestar doublestar star dot star")]
+  #[test_case("a/b/**/*.*", "a/b/c/d/e.f")]
+  #[test_case("a/b/**/c/**/d/*.*", "a/b/c/d/e.f")]
+  #[test_case("a/b/**/d/**/*.*", "a/b/c/d/e.f")]
+  #[test_case("a/b/**/d/**/*.*", "a/b/c/d/g/e.f")]
+  #[test_case("a/b/**/d/**/*.*", "a/b/c/d/g/g/e.f")]
+  #[test_case("a/b-*/**/z.js", "a/b-c/z.js")]
+  #[test_case("a/b-*/**/z.js", "a/b-c/d/e/z.js")]
+  #[test_case("*/*", "a/b" ; "star star a/b")]
+  #[test_case("a/b/c/*.md", "a/b/c/xyz.md")]
+  #[test_case("a/*/c/*.md", "a/bb.bb/c/xyz.md")]
+  #[test_case("a/*/c/*.md", "a/bb/c/xyz.md")]
+  #[test_case("a/*/c/*.md", "a/bbbb/c/xyz.md")]
+  #[test_case("**/*", "a/b/c" ; "doublestar star a/b/c")]
+  #[test_case("a/**/j/**/z/*.md", "a/b/c/d/e/j/n/p/o/z/c.md")]
+  #[test_case("a/**/z/*.md", "a/b/c/d/e/z/c.md")]
+  #[test_case("a/**/c/*.md", "a/bb.bb/aa/b.b/aa/c/xyz.md")]
+  #[test_case("a/**/c/*.md", "a/bb.bb/aa/bb/aa/c/xyz.md")]
+  #[test_case("/**", "/a/b" ; "slash doublestar /a/b")]
+  #[test_case("**/*", "a.b" ; "doublestar star a.b")]
+  #[test_case("**/*", "a.js" ; "doublestar star a.js")]
+  #[test_case("**/*.js", "a.js")]
+  // #[test_case("a/**/", "a/")]
+  #[test_case("**/*.js", "a/a.js")]
+  #[test_case("**/*.js", "a/a/b.js")]
+  #[test_case("a/**/b", "a/b" ; "a doublestar slash b")]
+  #[test_case("a/**b", "a/b" ; "a slash doublestar b")]
+  #[test_case("**/*.md", "a/b.md")]
+  #[test_case("**/*", "a/b/c.js")]
+  #[test_case("**/*", "a/b/c.txt")]
+  #[test_case("a/**/", "a/b/c/d/" ; "a doublestar slash")]
+  #[test_case("**/*", "a/b/c/d/a.js")]
+  #[test_case("a/b/**/*.js", "a/b/c/z.js")]
+  #[test_case("a/b/**/*.js", "a/b/z.js")]
+  #[test_case("**/*", "ab")]
+  #[test_case("**/*", "ab/c")]
+  #[test_case("**/*", "ab/c/d")]
+  #[test_case("**/*", "abc.js")]
+  #[test_case("**", "a" ; "doublestar a")]
+  #[test_case("**/**", "a" ; "doublestar doublestar a")]
+  #[test_case("**/**/*", "a" ; "doublestar doublestar star a")]
+  #[test_case("**/**/a", "a" ; "doublestar doublestar a a")]
+  // #[test_case("**/a/**", "a")]
+  // #[test_case("a/**", "a")]
+  #[test_case("**", "a/b" ; "doublestar a/b")]
+  #[test_case("**/**", "a/b" ; "doublestar doublestar a/b")]
+  #[test_case("**/**/*", "a/b" ; "doublestar doublestar star a/b")]
+  #[test_case("**/**/b", "a/b" ; "doublestar doublestar b a/b")]
+  #[test_case("**/b", "a/b" ; "doublestar b")]
+  // #[test_case("**/b/**", "a/b")]
+  // #[test_case("*/b/**", "a/b")]
+  #[test_case("a/**/*", "a/b" ; "a doublestar star a/b")]
+  #[test_case("a/**/**/*", "a/b" ; "a doublestar doublestar star a/b")]
+  #[test_case("**", "a/b/c" ; "doublestar a/b/c")]
+  #[test_case("**/**/*", "a/b/c" ; "doublestar doublestar star a/b/c")]
+  #[test_case("**/b/*", "a/b/c" ; "doublestar b star")]
+  #[test_case("**/b/**", "a/b/c" ; "doublestar b doublestar a/b/c")]
+  #[test_case("*/b/**", "a/b/c" ; "star b doublestar a/b/c")]
+  #[test_case("a/**/*", "a/b/c" ; "a doublestar star a/b/c")]
+  #[test_case("**", "a/b/c/d" ; "doublestar a/b/c/d")]
+  #[test_case("**/**", "a/b/c/d" ; "doublestar doublestar a/b/c/d")]
+  #[test_case("**/**/*", "a/b/c/d" ; "doublestar doublestar star a/b/c/d")]
+  #[test_case("**/**/d", "a/b/c/d" ; "double doublestar d")]
+  #[test_case("**/b/**", "a/b/c/d" ; "doublestar b doublestar a/b/c/d")]
+  #[test_case("**/b/*/*", "a/b/c/d" ; "doublestar b star star")]
+  #[test_case("**/d", "a/b/c/d" ; "doublestar d")]
+  #[test_case("*/b/**", "a/b/c/d" ; "star b doublestar a/b/c/d")]
+  #[test_case("a/**", "a/b/c/d" ; "a doublestar a/b/c/d")]
+  #[test_case("a/**/*", "a/b/c/d" ; "a doublestar star a/b/c/d")]
+  #[test_case("a/**/**/*", "a/b/c/d" ; "a doublestar doublestar star a/b/c/d")]
+  fn globstars(glob: &str, path: &str) {
+    assert!(glob_match(glob, path));
+  }
+
+  #[test_case("a/b/**/*.js", "a/d.js")]
+  #[test_case("a/b/**/*.js", "d.js")]
+  #[test_case("**c", "a/b/c")]
+  #[test_case("a/**c", "a/b/c")]
+  #[test_case("a/**z", "a/b/c")]
+  #[test_case("a/**b**/c", "a/b/c/b/c")]
+  #[test_case("a/b/c**/*.js", "a/b/c/d/e.js")]
+  #[test_case("a/**/*", "a" ; "a doublestar star a")]
+  #[test_case("a/**/**/*", "a" ; "a doublestar doublestar star a")]
+  #[test_case("a/**/**/**/*", "a" ; "a doublestar doublestar doublestar star a")]
+  #[test_case("**/a", "a/"; "doublestar a slash a/")]
+  #[test_case("a/**/*", "a/" ; "a doublestar star slash a/")]
+  #[test_case("a/**/**/*", "a/" ; "a doublestar doublestar star a/")]
+  #[test_case("a/**/**/**/*", "a/" ; "a doublestar doublestar doublestar star a/")]
+  #[test_case("**/a", "a/b" ; "doublestar a slash a/b")]
+  #[test_case("a/**/j/**/z/*.md", "a/b/c/j/e/z/c.txt")]
+  #[test_case("a/**/b", "a/bb")]
+  #[test_case("**/a", "a/c")]
+  #[test_case("**/a", "a/b" ; "doublestar a a/b")]
+  #[test_case("**/a", "a/x/y")]
+  #[test_case("**/a", "a/b/c/d" ; "doublestar a a/b/c/d")]
+  #[test_case("a/b/**/f", "a/b/c/d/")]
+  #[test_case("a/b/**/c{d,e}/**/xyz.md", "a/b/c/xyz.md")]
+  #[test_case("a/b/**/c{d,e}/**/xyz.md", "a/b/d/xyz.md")]
+  #[test_case("a/**/", "a/b")]
+  // #[test_case("**/*", "a/b/.js/c.txt")]
+  #[test_case("a/**/", "a/b/c/d")]
+  #[test_case("a/**/", "a/bb")]
+  #[test_case("a/**/", "a/cb")]
+  #[test_case("**/", "a" ; "doublestar a")]
+  #[test_case("**/a/*", "a" ; "doublestar a star")]
+  #[test_case("**/a/*/*", "a" ; "doublestar a star star")]
+  #[test_case("*/a/**", "a" ; "star a doublestar")]
+  #[test_case("**/", "a/b")]
+  #[test_case("**/b/*", "a/b" ; "doublestar b star")]
+  #[test_case("**/b/*/*", "a/b" ; "doublestar b star star a/b")]
+  #[test_case("b/**", "a/b")]
+  #[test_case("**/", "a/b/c")]
+  #[test_case("**/**/b", "a/b/c" ; "double doublestar b")]
+  #[test_case("**/b", "a/b/c" ; "doublestar b")]
+  #[test_case("**/b/*/*", "a/b/c" ; "doublestar b star star a/b/c")]
+  #[test_case("b/**", "a/b/c")]
+  #[test_case("**/", "a/b/c/d")]
+  #[test_case("**/d/*", "a/b/c/d")]
+  #[test_case("b/**", "a/b/c/d")]
+  fn globstars_not(glob: &str, path: &str) {
+    assert!(!glob_match(glob, path));
+  }
+
+  #[test_case("フ*/**/*", "フォルダ/aaa.js")]
+  #[test_case("フォ*/**/*", "フォルダ/aaa.js")]
+  #[test_case("フォル*/**/*", "フォルダ/aaa.js")]
+  #[test_case("フ*ル*/**/*", "フォルダ/aaa.js")]
+  #[test_case("フォルダ/**/*", "フォルダ/aaa.js")]
+  fn utf8(glob: &str, path: &str) {
+    assert!(glob_match(glob, path));
+  }
+
+  #[test_case("*!*.md", "!foo!.md" ; "not star")]
+  #[test_case("\\!*!*.md", "!foo!.md" ; "escaped not star")]
+  #[test_case("!*foo", "abc" ; "not foo")]
+  #[test_case("!foo*", "abc" ; "not foo then star")]
+  #[test_case("!xyz", "abc")]
+  #[test_case("*!*.*", "ba!r.js")]
+  #[test_case("*.md", "bar.md")]
+  #[test_case("*!*.*", "foo!.md")]
+  #[test_case("*!*.md", "foo!.md" ; "star not star dot star")]
+  #[test_case("*!.md", "foo!.md" ; "star not dot star")]
+  #[test_case("*.md", "foo!.md" ; "dot star")]
+  #[test_case("foo!.md", "foo!.md")]
+  #[test_case("*!*.md", "foo!bar.md")]
+  #[test_case("*b*.md", "foobar.md")]
+  #[test_case("a!!b", "a!!b" ; "a not not b")]
+  #[test_case("!a/b", "a" ; "not a then slash b a")]
+  #[test_case("!a/b", "a.b" ; "not a then slash b a.b")]
+  #[test_case("!a/b", "a/a")]
+  #[test_case("!a/b", "a/c")]
+  #[test_case("!a/b", "b/a")]
+  #[test_case("!a/b", "b/b")]
+  #[test_case("!a/b", "b/c")]
+  #[test_case("!!abc", "abc" ; "not not abc abc")]
+  #[test_case("!!!!abc", "abc" ; "not not not not abc abc")]
+  #[test_case("!!!!!!abc", "abc" ; "not not not not not not abc abc")]
+  #[test_case("!!!!!!!!abc", "abc" ; "not not not not not not not abc abc")]
+  #[test_case("!(*/*)", "a" ; "not capture star a")]
+  #[test_case("!(*/*)", "a.b")]
+  #[test_case("!(*/b)", "a")]
+  #[test_case("!(*/b)", "a.b" ; "not star slash b a dot b")]
+  #[test_case("!(*/b)", "a/a" ; "not star slash b a slash a")]
+  #[test_case("!(*/b)", "a/c" ; "not star slash b a slash c")]
+  #[test_case("!(*/b)", "b/a" ; "not star slash b b slash a")]
+  #[test_case("!(*/b)", "b/c" ; "not star slash b b slash c")]
+  #[test_case("!(a/b)", "a"; "not a slash b a")]
+  #[test_case("!(a/b)", "a.b")]
+  #[test_case("!(a/b)", "a/a" ; "not a slash b, a slash a")]
+  #[test_case("!(a/b)", "a/c" ; "not a slash b, a slash c")]
+  #[test_case("!(a/b)", "b/a" ; "not a slash b, b slash a")]
+  #[test_case("!(a/b)", "b/b" ; "not a slash b, b slash b")]
+  #[test_case("!(a/b)", "b/c" ; "not a slash b, b slash c")]
+  #[test_case("!*", "a/a")]
+  #[test_case("!*", "a/b" ; "not star a slash b")]
+  #[test_case("!*", "a/c")]
+  #[test_case("!*", "b/a" ; "not star b slash a")]
+  #[test_case("!*", "b/b")]
+  #[test_case("!*", "b/c")]
+  #[test_case("!*/*", "a")]
+  #[test_case("!*/*", "a.b" ; "not star a dot b")]
+  #[test_case("!*/b", "a" ; "not b a")]
+  #[test_case("!*/b", "a.b")]
+  #[test_case("!*/b", "a/a")]
+  #[test_case("!*/b", "a/c")]
+  #[test_case("!*/b", "b/a")]
+  #[test_case("!*/b", "b/c" ; "not b b slash c")]
+  #[test_case("!*/c", "a")]
+  #[test_case("!*/c", "a.b" ; "not c a dot b")]
+  #[test_case("!*/c", "a/a")]
+  #[test_case("!*/c", "a/b" ; "not c a slash b")]
+  #[test_case("!*/c", "b/a")]
+  #[test_case("!*/c", "b/b")]
+  #[test_case("!*a*", "foo")]
+  // #[test_case("!a/(*)", "a")]
+  // #[test_case("!a/(*)", "a.b")]
+  // #[test_case("!a/(*)", "b/a")]
+  // #[test_case("!a/(*)", "b/b")]
+  // #[test_case("!a/(*)", "b/c")]
+  // #[test_case("!a/(b)", "a")]
+  // #[test_case("!a/(b)", "a.b")]
+  // #[test_case("!a/(b)", "a/a")]
+  // #[test_case("!a/(b)", "a/c")]
+  // #[test_case("!a/(b)", "b/a")]
+  // #[test_case("!a/(b)", "b/b")]
+  // #[test_case("!a/(b)", "b/c")]
+  #[test_case("!a/*", "a" ; "not a / star")]
+  #[test_case("!a/*", "a.b")]
+  #[test_case("!a/*", "b/a")]
+  #[test_case("!a/*", "b/b")]
+  #[test_case("!a/*", "b/c")]
+  #[test_case("!f*b", "bar")]
+  #[test_case("!f*b", "foo")]
+  #[test_case("!**/*.md", "a.js" ; "doublestar md ajs 1")]
+  #[test_case("!**/*.md", "c.txt" ; "star md ctxt 1")]
+  #[test_case("!*.md", "a.js" ; "star md ajs 2")]
+  #[test_case("!*.md", "c.txt" ; "star md ctxt 2")]
+  #[test_case("!*.md", "abc.txt")]
+  #[test_case("!.md", "foo.md")]
+  #[test_case("!*.md", "b.txt")]
+  #[test_case("!a/*/*/a.js", "b/a/b/a.js" ; "aajs babajs 1")]
+  #[test_case("!a/*/*/a.js", "c/a/c/a.js" ; "aajs cacajs 1")]
+  #[test_case("!a/a*.txt", "a/b.txt" ; "aatxt abtxt 1")]
+  #[test_case("!a/a*.txt", "a/c.txt" ; "aatxt actxt 1")]
+  #[test_case("!a.a*.txt", "a.b.txt" ; "aatxt abtxt 2")]
+  #[test_case("!a.a*.txt", "a.c.txt" ; "aatxt actxt 2")]
+  #[test_case("!*.md", "a.js" ; "not star md ajs 1")]
+  #[test_case("!*.md", "b.txt" ; "md b txt")]
+  #[test_case("!a/**/a.js", "b/a/b/a.js" ; "aajs babajs 2")]
+  #[test_case("!a/**/a.js", "c/a/c/a.js" ; "aajs cacajs 2")]
+  #[test_case("!**/*.md", "a/b.js")]
+  #[test_case("!**/*.md", "a.js" ; "not doublestar md ajs 2")]
+  #[test_case("**/*.md", "a/b.md" ; "md ab txt")]
+  #[test_case("**/*.md", "a.md")]
+  #[test_case("!**/*.md", "a/b.js" ; "doublestar md ab js")]
+  #[test_case("!*.md", "a/b.js" ; "star md ab js")]
+  #[test_case("!*.md", "a/b.md")]
+  #[test_case("!**/*.md", "c.txt")]
+  fn negation(glob: &str, path: &str) {
+    assert!(glob_match(glob, path));
+  }
+
+  #[test_case("!*", "abc")]
+  #[test_case("!abc", "abc")]
+  #[test_case("*!.md", "bar.md")]
+  #[test_case("foo!.md", "bar.md")]
+  #[test_case("\\!*!*.md", "foo!.md" ; "not star not star md foo md")]
+  #[test_case("\\!*!*.md", "foo!bar.md")]
+  #[test_case("a!!b", "a")]
+  #[test_case("a!!b", "aa")]
+  #[test_case("a!!b", "a/b" ; "a not not b a slash b")]
+  #[test_case("a!!b", "a!b" ; "a not not b a!b")]
+  #[test_case("a!!b", "a/!!/b" ; "a not not b a slash not not slash b")]
+  #[test_case("!a/b", "a/b" ; "not a slash b a slash b")]
+  #[test_case("!abc", "abc" ; "not abc abc")]
+  #[test_case("!!!abc", "abc" ; "not not not abc abc")]
+  #[test_case("!!!!!abc", "abc" ; "not not not not not abc abc")]
+  #[test_case("!!!!!!!abc", "abc" ; "not not not not not not not abc abc")]
+  // #[test_case("!(*/*)", "a/a")]
+  // #[test_case("!(*/*)", "a/b")]
+  // #[test_case("!(*/*)", "a/c")]
+  // #[test_case("!(*/*)", "b/a")]
+  // #[test_case("!(*/*)", "b/b")]
+  // #[test_case("!(*/*)", "b/c")]
+  // #[test_case("!(*/b)", "a/b")]
+  // #[test_case("!(*/b)", "b/b")]
+  // #[test_case("!(a/b)", "a/b")]
+  #[test_case("!*", "a")]
+  #[test_case("!*", "a.b" ; "not star a dot b")]
+  #[test_case("!*/*", "a/a")]
+  #[test_case("!*/*", "a/b")]
+  #[test_case("!*/*", "a/c")]
+  #[test_case("!*/*", "b/a")]
+  #[test_case("!*/*", "b/b")]
+  #[test_case("!*/*", "b/c")]
+  #[test_case("!*/b", "a/b")]
+  #[test_case("!*/b", "b/b")]
+  #[test_case("!*/c", "a/c" ; "not star slash c a slash c")]
+  #[test_case("!*/c", "b/c")]
+  #[test_case("!*a*", "bar")]
+  #[test_case("!*a*", "fab")]
+  // #[test_case("!a/(*)", "a/a")]
+  // #[test_case("!a/(*)", "a/b")]
+  // #[test_case("!a/(*)", "a/c")]
+  // #[test_case("!a/(b)", "a/b")]
+  #[test_case("!a/*", "a/a")]
+  #[test_case("!a/*", "a/b")]
+  #[test_case("!a/*", "a/c")]
+  #[test_case("!f*b", "fab")]
+  #[test_case("!.md", ".md")]
+  // #[test_case("!**/*.md", "b.md")]
+  #[test_case("!*.md", "b.md")]
+  #[test_case("!*.md", "abc.md")]
+  #[test_case("!*.md", "foo.md")]
+  #[test_case("!*.md", "c.md")]
+  #[test_case("!a/*/a.js", "a/a/a.js")]
+  #[test_case("!a/*/a.js", "a/b/a.js")]
+  #[test_case("!a/*/a.js", "a/c/a.js")]
+  #[test_case("!a/*/*/a.js", "a/a/a/a.js")]
+  #[test_case("!a/a*.txt", "a/a.txt" ; "not a slash star txt a slash a dot txt")]
+  #[test_case("!a.a*.txt", "a.a.txt" ; "not a dot a star txt a dot a dot txt")]
+  #[test_case("!a/*.txt", "a/a.txt")]
+  #[test_case("!a/*.txt", "a/b.txt")]
+  #[test_case("!a/*.txt", "a/c.txt")]
+  #[test_case("!*.md", "c.md" ; "not star md c dot md")]
+  // #[test_case("!**/a.js", "a/a/a.js")]
+  // #[test_case("!**/a.js", "a/b/a.js")]
+  // #[test_case("!**/a.js", "a/c/a.js")]
+  #[test_case("!a/**/a.js", "a/a/a/a.js" ; "not a slash doublestar slash a js a/a/a/a.js")]
+  // #[test_case("!**/*.md", "a.md")]
+  #[test_case("**/*.md", "a/b.js")]
+  #[test_case("**/*.md", "a.js")]
+  #[test_case("!**/*.md", "a/b.md")]
+  // #[test_case("!**/*.md", "a.md")]
+  #[test_case("!*.md", "a.md")]
+  // #[test_case("!**/*.md", "b.md")]
+  fn negation_not(glob: &str, path: &str) {
+    assert!(!glob_match(glob, path));
+  }
+
+  #[test_case("?", "a")]
+  #[test_case("??", "aa")]
+  #[test_case("??", "ab")]
+  #[test_case("???", "aaa")]
+  #[test_case("a?c", "aac")]
+  #[test_case("a?c", "abc")]
+  #[test_case("a?b", "acb")]
+  #[test_case("a/??/c/??/e.md", "a/bb/c/dd/e.md")]
+  #[test_case("a/?/c.md", "a/b/c.md")]
+  #[test_case("a/?/c/?/e.md", "a/b/c/d/e.md")]
+  #[test_case("a/?/c/???/e.md", "a/b/c/zzz/e.md")]
+  #[test_case("a/??/c.md", "a/bb/c.md")]
+  #[test_case("a/???/c.md", "a/bbb/c.md")]
+  #[test_case("a/????/c.md", "a/bbbb/c.md")]
+  fn question_mark(glob: &str, path: &str) {
+    assert!(glob_match(glob, path));
+  }
+
+  #[test_case("?", "aa")]
+  #[test_case("?", "ab")]
+  #[test_case("?", "aaa")]
+  #[test_case("?", "abcdefg")]
+  #[test_case("??", "a")]
+  #[test_case("??", "aaa" ; "double qmark aaa")]
+  #[test_case("??", "abcdefg" ; "double qmark abcdefg")]
+  #[test_case("???", "a" ; "triple qmark a")]
+  #[test_case("???", "aa" ; "triple qmark aa")]
+  #[test_case("???", "ab" ; "triple qmark ab")]
+  #[test_case("???", "abcdefg" ; "triple qmark abcdefg")]
+  #[test_case("a?c", "aaa")]
+  #[test_case("ab?", "a")]
+  #[test_case("ab?", "aa")]
+  #[test_case("ab?", "ab")]
+  #[test_case("ab?", "ac")]
+  #[test_case("ab?", "abcd")]
+  #[test_case("ab?", "abbb")]
+  #[test_case("a/?/c/?/e.md", "a/bb/c/dd/e.md")]
+  #[test_case("a/??/c.md", "a/bbb/c.md")]
+  #[test_case("a/?/c/???/e.md", "a/b/c/d/e.md")]
+  #[test_case("a/?/c.md", "a/bb/c.md")]
+  fn question_mark_not(glob: &str, path: &str) {
+    assert!(!glob_match(glob, path));
+  }
+
+  #[test_case("{a,b,c}", "a")]
+  #[test_case("{a,b,c}", "b")]
+  #[test_case("{a,b,c}", "c")]
+  #[test_case("a/{a,b}", "a/a")]
+  #[test_case("a/{a,b}", "a/b")]
+  #[test_case("a/{a,b,c}", "a/c")]
+  #[test_case("a{b,bc}.txt", "abc.txt")]
+  #[test_case("foo[{a,b}]baz", "foo{baz")]
+  #[test_case("a{,b}.txt", "a.txt" ; "abtxt 1")]
+  #[test_case("a{b,}.txt", "a.txt" ; "abtxt 2")]
+  #[test_case("a{a,b,}.txt", "aa.txt" ; "aabtxt 1")]
+  #[test_case("a{a,b,}.txt", "aa.txt" ; "aabtxt 2")]
+  #[test_case("a{,b}.txt", "ab.txt" ; "abtxt 3")]
+  #[test_case("a{b,}.txt", "ab.txt" ; "abtxt 4")]
+  // #[test_case("{a/,}a/**", "a")]
+  #[test_case("a{a,b/}*.txt", "aa.txt")]
+  #[test_case("a{a,b/}*.txt", "ab/.txt")]
+  #[test_case("a{a,b/}*.txt", "ab/a.txt")]
+  // #[test_case("{a/,}a/**", "a/")]
+  #[test_case("{a/,}a/**", "a/a/" ; "ending slash")]
+  // #[test_case("{a/,}a/**", "a/a")]
+  #[test_case("{a/,}a/**", "a/a/a" ; "ending slash 1")]
+  #[test_case("{a/,}a/**", "a/a/" ; "ending slash 2")]
+  #[test_case("{a/,}a/**", "a/a/a/" ; "ending slash 3")]
+  #[test_case("{a/,}b/**", "a/b/a/")]
+  #[test_case("{a/,}b/**", "b/a/")]
+  #[test_case("a{,/}*.txt", "a.txt")]
+  #[test_case("a{,/}*.txt", "ab.txt")]
+  #[test_case("a{,/}*.txt", "a/b.txt")]
+  #[test_case("a{,/}*.txt", "a/ab.txt")]
+  #[test_case("a{,.*{foo,db},\\(bar\\)}.txt", "a.txt")]
+  #[test_case("a{,.*{foo,db},\\(bar\\)}.txt", "a.db.txt" ; "a db txt 1")]
+  #[test_case("a{,*.{foo,db},\\(bar\\)}.txt", "a.db.txt" ; "a db txt 2")]
+  #[test_case("a{,.*{foo,db},\\(bar\\)}", "a.db" ; "a db 1")]
+  #[test_case("a{,*.{foo,db},\\(bar\\)}", "a.db" ; "a db 2")]
+  #[test_case("{,.*{foo,db},\\(bar\\)}", ".db")]
+  #[test_case("{*,*.{foo,db},\\(bar\\)}", "a")]
+  #[test_case("{,*.{foo,db},\\(bar\\)}", "a.db")]
+  #[test_case("a/b/**/c{d,e}/**/xyz.md", "a/b/cd/xyz.md")]
+  #[test_case("a/b/**/{c,d,e}/**/xyz.md", "a/b/c/xyz.md")]
+  #[test_case("a/b/**/{c,d,e}/**/xyz.md", "a/b/d/xyz.md")]
+  #[test_case("a/b/**/{c,d,e}/**/xyz.md", "a/b/e/xyz.md")]
+  #[test_case("*{a,b}*", "xax")]
+  #[test_case("*{a,b}*", "xxax")]
+  #[test_case("*{a,b}*", "xbx")]
+  #[test_case("*{*a,b}", "xba")]
+  #[test_case("*{*a,b}", "xb")]
+  #[test_case("*???", "aaa" ; "aaa 1")]
+  #[test_case("*****???", "aaa" ; "aaa 2")]
+  #[test_case("a*?c", "aac")]
+  #[test_case("a*?c", "abc" ; "abc")]
+  #[test_case("a**?c", "abc" ; "abc 1")]
+  #[test_case("a**?c", "acc")]
+  #[test_case("a*****?c", "abc")]
+  #[test_case("*****?", "a")]
+  #[test_case("*****?", "aa")]
+  #[test_case("*****?", "abc")]
+  #[test_case("*****?", "zzz")]
+  #[test_case("*****?", "bbb" ; "bbb 1")]
+  #[test_case("*****?", "aaaa" ; "aaaa 1")]
+  #[test_case("*****??", "aa" ; "aa 2")]
+  #[test_case("*****??", "abc" ; "abc 2")]
+  #[test_case("*****??", "zzz" ; "zzz 2")]
+  #[test_case("*****??", "bbb" ; "bbb 2")]
+  #[test_case("*****??", "aaaa" ; "aaaa 2")]
+  #[test_case("?*****??", "abc" ; "abc 3")]
+  #[test_case("?*****??", "zzz" ; "zzz 3")]
+  #[test_case("?*****??", "bbb" ; "bbb 3")]
+  #[test_case("?*****??", "aaaa")]
+  #[test_case("?*****?c", "abc" ; "1")]
+  #[test_case("?***?****c", "abc" ; "abc 4")]
+  #[test_case("?***?****?", "abc" ; "abc 5")]
+  #[test_case("?***?****?", "bbb" ; "bbb 4")]
+  #[test_case("?***?****?", "zzz" ;  "zzz 4")]
+  #[test_case("?***?****", "abc" ; "abc 6")]
+  #[test_case("*******c", "abc" ; "2")]
+  #[test_case("*******?", "abc" ; "abc 7")]
+  #[test_case("a*cd**?**??k", "abcdecdhjk" ; "lots of options")]
+  #[test_case("a**?**cd**?**??k", "abcdecdhjk" ; "lots of options 1")]
+  #[test_case("a**?**cd**?**??k***", "abcdecdhjk" ; "lots of options 2")]
+  #[test_case("a**?**cd**?**??***k", "abcdecdhjk" ; "lots of options 3")]
+  #[test_case("a**?**cd**?**??***k**", "abcdecdhjk" ; "lots of options 4")]
+  #[test_case("a****c**?**??*****", "abcdecdhjk")]
+  #[test_case("a/?/c/?/*/e.md", "a/b/c/d/e/e.md")]
+  #[test_case("a/?/c/?/*/e.md", "a/b/c/d/efghijk/e.md")]
+  #[test_case("a/?/**/e.md", "a/b/c/d/efghijk/e.md")]
+  #[test_case("a/??/e.md", "a/bb/e.md")]
+  #[test_case("a/?/**/e.md", "a/b/ccc/e.md")]
+  #[test_case("a/*/?/**/e.md", "a/b/c/d/efghijk/e.md" ; "long path option double star")]
+  #[test_case("a/*/?/**/e.md", "a/b/c/d/efgh.ijk/e.md")]
+  #[test_case("a/*/?/**/e.md", "a/b.bb/c/d/efgh.ijk/e.md")]
+  #[test_case("a/*/?/**/e.md", "a/bbb/c/d/efgh.ijk/e.md")]
+  #[test_case("a/*/ab??.md", "a/bbb/abcd.md")]
+  #[test_case("a/bbb/ab??.md", "a/bbb/abcd.md")]
+  #[test_case("a/bbb/ab???md", "a/bbb/abcd.md" ; "long path option")]
+  #[test_case("a{,*.{foo,db},\\(bar\\)}.txt", "a.txt" ; "a.txt 2")]
+  // #[test_case("a{,.*{foo,db},\\(bar\\)}", "a")]
+  // #[test_case("a{,*.{foo,db},\\(bar\\)}", "a")]
+  fn braces(glob: &str, path: &str) {
+    assert!(glob_match(glob, path));
+  }
+
+  #[test_case("{a,b,c}", "aa")]
+  #[test_case("{a,b,c}", "bb")]
+  #[test_case("{a,b,c}", "cc")]
+  #[test_case("a/{a,b}", "a/c")]
+  #[test_case("a/{a,b}", "b/b")]
+  #[test_case("a/{a,b,c}", "b/b")]
+  #[test_case("a{,b}.txt", "abc.txt" ; "a brace b txt abc.txt")]
+  #[test_case("a{a,b,}.txt", "abc.txt")]
+  #[test_case("a{b,}.txt", "abc.txt")]
+  #[test_case("a{,.*{foo,db},\\(bar\\)}.txt", "adb.txt" ; "a brace comma dot star abd.txt")]
+  #[test_case("a{,*.{foo,db},\\(bar\\)}.txt", "adb.txt" ; "a brace comma star dot abd.txt")]
+  #[test_case("a{,.*{foo,db},\\(bar\\)}", "adb" ; "a brace comma dot star abd")]
+  #[test_case("a{,*.{foo,db},\\(bar\\)}", "adb" ; "a brace comma star dot abd")]
+  #[test_case("{,.*{foo,db},\\(bar\\)}", "a" ; "brace comma dot star a")]
+  #[test_case("{,*.{foo,db},\\(bar\\)}", "a" ; "brace comma star dot a")]
+  #[test_case("{,*.{foo,db},\\(bar\\)}", "adb" ; "brace comma star dot abd")]
+  #[test_case("{,.*{foo,db},\\(bar\\)}", "adb" ; "brace comma dot star abd")]
+  #[test_case("{,.*{foo,db},\\(bar\\)}", "a.db")]
+  #[test_case("a/b/**/c{d,e}/**/xyz.md", "a/b/c/xyz.md")]
+  #[test_case("a/b/**/c{d,e}/**/xyz.md", "a/b/d/xyz.md")]
+  #[test_case("*??", "a" ; "star qmark qmark a")]
+  #[test_case("*???", "aa" ; "star qmark qmark qmark aa")]
+  #[test_case("*****??", "a" ; "star star star star star qmark qmark a")]
+  #[test_case("*****???", "aa" ; "star star star star star qmark qmark qmark aa")]
+  #[test_case("a*?c", "aaa")]
+  #[test_case("a**?c", "abb")]
+  #[test_case("?*****??", "a" ; "qmark star star star star star qmark qmark a")]
+  #[test_case("?*****??", "aa")]
+  #[test_case("?*****?c", "abb")]
+  #[test_case("?*****?c", "zzz" ; "qmark star star star star star qmark qmark zzz")]
+  #[test_case("?***?****c", "bbb")]
+  #[test_case("?***?****c", "zzz" ; "qmark star star star qmark star star star star c zzz")]
+  #[test_case("a/?/c/?/*/e.md", "a/b/c/d/e.md")]
+  #[test_case("a/?/e.md", "a/bb/e.md" ; "a qmark e.md")]
+  #[test_case("a/?/**/e.md", "a/bb/e.md" ; "a qmark doublestar e.md")]
+  fn braces_not(glob: &str, path: &str) {
+    assert!(!glob_match(glob, path));
+  }
+
+  #[test_case("a/*[a-z]x/c", "a/yybx/c" => Some(vec!["yy", "b"]))]
+  #[test_case("a/{b,c[}]*}", "a/c}xx" => Some(vec!["c}xx", "}", "xx"]))]
+  #[test_case("a/b", "a/b" => Some(vec![]))]
+  #[test_case("a/*/c", "a/bx/c" => Some(vec!["bx"]))]
+  #[test_case("a/*/c", "a/test/c" => Some(vec!["test"]))]
+  #[test_case("a/*/c/*/e", "a/b/c/d/e" => Some(vec!["b", "d"]))]
+  #[test_case("a/{b,x}/c", "a/b/c" => Some(vec!["b"]))]
+  #[test_case("a/{b,x}/c", "a/x/c" => Some(vec!["x"]))]
+  #[test_case("a/?/c", "a/b/c" => Some(vec!["b"]))]
+  #[test_case("a/*?x/c", "a/yybx/c" => Some(vec!["yy", "b"]))]
+  #[test_case("a/{b*c,c}y", "a/bdcy" => Some(vec!["bdc", "d"]))]
+  #[test_case("a/{b*,c}y", "a/bdy" => Some(vec!["bd", "d"]))]
+  #[test_case("a/{b*c,c}", "a/bdc" => Some(vec!["bdc", "d"]))]
+  #[test_case("a/{b*,c}", "a/bd" => Some(vec!["bd", "d"]))]
+  #[test_case("a/{b*,c}", "a/c" => Some(vec!["c", ""]))]
+  #[test_case("a/{b{c,d},c}y", "a/bdy" => Some(vec!["bd", "d"]))]
+  #[test_case("a/{b*,c*}y", "a/bdy" => Some(vec!["bd", "d", ""]) ; "a/b*y or a/c*y a/bdy expects some vec bd d")]
+  #[test_case("a/{b*,c*}y", "a/cdy" => Some(vec!["cd", "", "d"]))]
+  #[test_case("a/{b,c}", "a/b" => Some(vec!["b"]))]
+  #[test_case("a/{b,c}", "a/c" => Some(vec!["c"]) ; "a/b or a/c a/c expects some vec c")]
+  #[test_case("a/{b,c[}]*}", "a/b" => Some(vec!["b", "", ""]) ; "a slash bracket b or c a/b expects some vec b")]
+  // assert\.deepEqual\(([!])?capture\('(.*?)', ['"](.*?)['"]\), (.*)?\);
+  // #[test_case("$2", "$3" => Some(vec!$4))]
+  #[test_case("test/*", "test/foo" => Some(vec!["foo"]))]
+  #[test_case("test/*/bar", "test/foo/bar" => Some(vec!["foo"]))]
+  #[test_case("test/*/bar/*", "test/foo/bar/baz" => Some(vec!["foo", "baz"]))]
+  #[test_case("test/*.js", "test/foo.js" => Some(vec!["foo"]))]
+  #[test_case("test/*-controller.js", "test/foo-controller.js" => Some(vec!["foo"]))]
+  #[test_case("test/**/*.js", "test/a.js" => Some(vec!["", "a"]))]
+  #[test_case("test/**/*.js", "test/dir/a.js" => Some(vec!["dir", "a"]))]
+  #[test_case("test/**/*.js", "test/dir/test/a.js" => Some(vec!["dir/test", "a"]))]
+  #[test_case("**/*.js", "test/dir/a.js" => Some(vec!["test/dir", "a"]))]
+  #[test_case("**/**/**/**/a", "foo/bar/baz/a" => Some(vec!["foo/bar/baz"]))]
+  #[test_case("a/{b/**/y,c/**/d}", "a/b/y" => Some(vec!["b/y", "", ""]))]
+  #[test_case("a/{b/**/y,c/**/d}", "a/b/x/x/y" => Some(vec!["b/x/x/y", "x/x", ""]))]
+  #[test_case("a/{b/**/y,c/**/d}", "a/c/x/x/d" => Some(vec!["c/x/x/d", "", "x/x"]))]
+  #[test_case("a/{b/**/**/y,c/**/**/d}", "a/b/x/x/x/x/x/y" => Some(vec!["b/x/x/x/x/x/y", "x/x/x/x/x", ""]))]
+  #[test_case("a/{b/**/**/y,c/**/**/d}", "a/c/x/x/x/x/x/d" => Some(vec!["c/x/x/x/x/x/d", "", "x/x/x/x/x"]))]
+  #[test_case("some/**/{a,b,c}/**/needle.txt", "some/path/a/to/the/needle.txt" => Some(vec!["path", "a", "to/the"]))]
+  fn test_captures(glob: &'static str, path: &'static str) -> Option<Vec<&'static str>> {
+    glob_match_with_captures(glob, path)
+      .map(|v| v.into_iter().map(|capture| &path[capture]).collect())
+  }
+
+  // https://github.com/devongovett/glob-match/issues/1
+  #[test_case("{*{??*{??**,Uz*zz}w**{*{**a,z***b*[!}w??*azzzzzzzz*!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!z[za,z&zz}w**z*z*}")]
+  #[test_case("**** *{*{??*{??***\u{5} *{*{??*{??***\u{5},\0U\0}]*****\u{1},\0***\0,\0\0}w****,\0U\0}]*****\u{1},\0***\0,\0\0}w*****\u{1}***{}*.*\0\0*\0")]
+  fn fuzz_tests(fuzz: &str) {
+    assert!(!glob_match(fuzz, fuzz));
   }
 }


### PR DESCRIPTION
This closes #5. The PR is split into two commits. The first is kinda a precursor. I had a whole load of tests breaking to begin with which were tough to debug so now rather than a handful of tests with assertions, we now use `test_case` which exposes pass/fail for all 1200. The second PR is the 'meat'. It overrides 3 functions based on a feature flag.

To preserve performance, the non-unicode version still uses u8 rather than slices, though I feel like the perf overhead wouldn't be too large...

Note that rust requires tests to have a unique name so I have had to manually disambiguate any clashes (over 300 🥴). Some may be pretty crappy. In the process I have also removed identical tests.