### PR TITLE
Fix empty alternatives and ** in brace groups

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,8 +89,12 @@ fn glob_match_internal<'a>(
           if is_globstar {
             state.glob_index += 2;
 
-            if glob.len() == state.glob_index {
-              // A trailing ** segment without a following separator.
+            if glob.len() == state.glob_index
+              || (brace_stack.length > 0
+                && matches!(glob[state.glob_index], b'}' | b','))
+            {
+              // A trailing ** segment without a following separator
+              // (or at end of a brace alternative).
               state.globstar = state.wildcard;
             } else if (state.glob_index < 3 || glob[state.glob_index - 3] == b'/')
               && glob[state.glob_index] == b'/'
@@ -1484,6 +1488,11 @@ mod tests {
     // assert!(glob_match("a/**", "a"));
     assert!(glob_match("**", "a"));
     assert!(glob_match("a{,/**}", "a"));
+    assert!(glob_match("a{,/**}", "a/b"));
+    assert!(glob_match("a{,/**}", "a/b/c"));
+    assert!(glob_match("a{ ,**}", "a "));
+    assert!(glob_match("a{ ,**}", "a /b"));
+    assert!(glob_match("a{ ,**}", "a /b/c"));
     assert!(glob_match("**", "a/"));
     assert!(glob_match("a/**", "a/"));
     assert!(glob_match("**", "a/b/c/d"));


### PR DESCRIPTION
## Summary

Two fixes for brace group (alternation) handling:

1. **Empty alternatives at end-of-path**: Patterns like `a{,b}` failed to match `"a"` when the empty option fell at end-of-path
2. **`**` inside braces not crossing `/`**: Patterns like `a{,/**}` treated `**` as `*` because globstar detection didn't recognize `}` or `,` as end-of-alternative

## Details

### Empty alternatives

Patterns like `a{,b}` should match both `"ab"` (via the `b` alternative) and `"a"` (via the empty alternative). The empty alternative already worked when there was more path to consume after the brace group (e.g. `a{,b}.txt` matching `a.txt`), but failed when the brace group appeared at the end of the pattern matching the end of the path.

This was caused by:
1. `b'{' if state.path_index < path.len()` — prevented entering brace groups when all path input was already consumed, even though an empty alternative would match zero characters
2. `longest_brace_match` used `0` as both the "no match found" sentinel and as a valid match position, so an empty alternative matching at position 0 was indistinguishable from no match

The fix removes the guard and stores `path_index + 1` in `longest_brace_match`, making `0` unambiguously "no match". The single read site in `pop` subtracts 1, and the existing `> 0` check remains correct.

### `**` inside braces

The globstar detection at line 92 only recognized a trailing `**` when it was at the literal end of the glob string (`glob.len() == state.glob_index`). Inside braces like `{,/**}`, the `**` is followed by `}`, so `state.globstar` was never set and it behaved like a regular `*` that can't cross `/`.

The fix also treats `}` and `,` as end-of-alternative when inside braces, enabling globstar behavior.

## Test plan

- [x] All 16 existing tests pass
- [x] Uncommented and verified 3 previously disabled test cases:
  - `a{,/**}` matches `"a"`
  - `a{,.*{foo,db},\(bar\)}` matches `"a"`
  - `a{,*.{foo,db},\(bar\)}` matches `"a"`
- [x] New test cases for `**` crossing `/` inside braces:
  - `a{,/**}` matches `"a/b"` and `"a/b/c"`
  - `a{ ,**}` matches `"a "`, `"a /b"`, and `"a /b/c"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)